### PR TITLE
Carousel controls handling for multiple client-layers 

### DIFF
--- a/tile-client/src/main/webapp/css/layercontrols.css
+++ b/tile-client/src/main/webapp/css/layercontrols.css
@@ -45,7 +45,6 @@
     position: relative;  
     width: 612px;
     font-size: 12px;
-    overflow: auto;
 }
 
 .light-theme #layer-controls-content {

--- a/tile-client/src/main/webapp/css/scrollbar.css
+++ b/tile-client/src/main/webapp/css/scrollbar.css
@@ -16,6 +16,10 @@
     border-radius: 10px;
 }
 
+::-webkit-scrollbar-thumb {
+    cursor:pointer;
+}
+
 .light-theme ::-webkit-scrollbar-thumb {
     border-radius: 10px;
     background-color: #fff;

--- a/tile-client/src/main/webapp/js/layer/LayerControls.js
+++ b/tile-client/src/main/webapp/js/layer/LayerControls.js
@@ -174,9 +174,6 @@ define(function (require) {
         $toggleBox.click(function () {
             var value = $toggleBox.prop("checked");
             layer.setVisibility( value );
-            if (layer.domain === "client") {
-                layer.setCarouselEnabled( value );
-            }
         });
         // set tooltip
         Util.enableTooltip( $toggleBox,

--- a/tile-client/src/main/webapp/js/layer/annotation/AnnotationLayer.js
+++ b/tile-client/src/main/webapp/js/layer/annotation/AnnotationLayer.js
@@ -104,6 +104,7 @@ define(function (require) {
             var that = this;
 
             this._super( spec, map );
+            this.domain = 'annotation';
             this.renderer = renderer;
             this.details = details;
 

--- a/tile-client/src/main/webapp/js/layer/client/renderers/GenericHtmlRenderer.js
+++ b/tile-client/src/main/webapp/js/layer/client/renderers/GenericHtmlRenderer.js
@@ -326,7 +326,7 @@ define(function (require) {
             var idKey = this.spec.idKey,
                 click = {
                     value : value,
-                    tilekey : this.parent.getTileFocus()
+                    tilekey : this.parent.map.getTileFocus()
                 };
             click[idKey] = value[idKey];
             this.parent.setClick( click );


### PR DESCRIPTION
Carousel controls now always appears on the top-most visible client layer with multiple views. Moved tile-focus tracking to map to remove redundancies with multiple client layers. Modified PubSub publish order to include parent channels.
