### PR TITLE
refs #8458 - Layer config order is now preserved in tile-client.

### DIFF
--- a/tile-client/src/main/webapp/js/customization.js
+++ b/tile-client/src/main/webapp/js/customization.js
@@ -27,7 +27,7 @@
 /*global OpenLayers */
 
 /**
- * Performs cusomizations on the main window.
+ * Performs customizations on the main window.
  *
  * Default implementation is a no-op.
  */

--- a/tile-client/src/main/webapp/js/layer/server/ServerLayer.js
+++ b/tile-client/src/main/webapp/js/layer/server/ServerLayer.js
@@ -345,20 +345,31 @@ define(function (require) {
         },
 
 
+        /**
+         * Has the filter value been locked?
+         */
         isFilterValueLocked: function( index ) {
             return this.getLayerSpec().preservelegendrange[ index ];
         },
 
 
+        /**
+         * Set whether or not the filter value is locked
+         */
         setFilterValueLocking: function( index, value ) {
             this.getLayerSpec().preservelegendrange[ index ] = value;
         },
+
 
         /**
          * @param {number} zIndex - The new z-order value of the layer, where 0 is front.
          */
         setZIndex: function ( zIndex ) {
-            this.map.setLayerIndex( this.layer.olLayer_, zIndex );
+            // we by-pass the OpenLayers.Map.setLayerIndex() method and manually
+            // set the z-index of the layer dev. setLayerIndex sets a relative
+            // index based on current map layers, which then sets a z-index. This
+            // caused issues with async layer loading.
+            $( this.layer.olLayer_.div ).css( 'z-index', zIndex );
             PubSub.publish( this.getChannel(), { field: 'zIndex', value: zIndex });
         },
 
@@ -367,7 +378,7 @@ define(function (require) {
          * Get the layers zIndex
          */
         getZIndex: function () {
-            return this.map.getLayerIndex( this.layer.olLayer_ );
+            return $( this.layer.olLayer_.div ).css( 'z-index' );
         },
 
 

--- a/tile-client/src/main/webapp/js/main.js
+++ b/tile-client/src/main/webapp/js/main.js
@@ -137,33 +137,48 @@ require(['./ApertureConfig',
                 return configurations;
 	        };
 
+            /**
+             * Iterate through server layers, and append zIndex to
+             * mirror the top-down ordering set in the config file.
+             */
 	        getServerLayers = function( rootNode, filter ) {
-	            var layers = getLayers( rootNode, filter, 'server' ),
-	                zIndex = 1, i;
+	            var Z_INDEX_OFFSET = 1,
+	                layers = getLayers( rootNode, filter, 'server' ),
+	                i;
 	            for ( i=0; i<layers.length; i++ ) {
-	                layers[i].zIndex = zIndex++;
+	                layers[i].zIndex = Z_INDEX_OFFSET + ( layers.length - i );
 	            }
 	            return layers;
             };
 
+            /**
+             * Iterate through client layers, and append zIndex to
+             * mirror the top-down ordering set in the config file.
+             */
             getClientLayers = function( rootNode, filter ) {
-                var layers = getLayers( rootNode, filter, 'client' ),
-                    zIndex = 1000, i;
+                var Z_INDEX_OFFSET = 1000,
+                    layers = getLayers( rootNode, filter, 'client' ),
+                    i;
                 // group client layers based on common name
                 layers = groupClientLayers( layers );
                 for ( i=0; i<layers.length; i++ ) {
-                    layers[i].zIndex = zIndex++;
+                    layers[i].zIndex = Z_INDEX_OFFSET + ( layers.length - i );
                 }
                 return layers;
             };
 
-	        getAnnotationLayers = function( allLayers, filter ) {
-		        var i, validLayers =[],
-		            zIndex = 500;
-		        for (i=0; i<allLayers.length; i++) {
-			        if ( filter( allLayers[i] ) ) {
-			            allLayers[i].zIndex = zIndex++;
-				        validLayers.push( allLayers[i] );
+            /**
+             * Iterate through annotation layers, and append zIndex to
+             * mirror the top-down ordering set in the config file.
+             */
+	        getAnnotationLayers = function( layers, filter ) {
+		        var Z_INDEX_OFFSET = 500,
+                    validLayers =[],
+		            i;
+		        for (i=0; i<layers.length; i++) {
+			        if ( filter( layers[i] ) ) {
+			            layers[i].zIndex = Z_INDEX_OFFSET + ( layers.length - i );
+				        validLayers.push( layers[i] );
 			        }
 		        }
 		        return validLayers;
@@ -307,6 +322,7 @@ require(['./ApertureConfig',
                             $.merge( layers, clientLayers );
                             $.merge( layers, serverLayers );
                             $.merge( layers, annotationLayers );
+
                             // create layer controls
                             new LayerControls( layerControlsContent, layers, UICustomization.customizeSettings ).noop();
                             // create the carousel controls


### PR DESCRIPTION
Layer config order is now preserved, top-down, in the z-Indices and layer controls. Priority is still client-> annotation -> server.
