### PR TITLE
Add accumulator-based tiling.  

### DIFF
--- a/tile-examples/julia-demo-live/src/main/java/com/oculusinfo/julia/JuliaLiveTest.java
+++ b/tile-examples/julia-demo-live/src/main/java/com/oculusinfo/julia/JuliaLiveTest.java
@@ -21,7 +21,6 @@ import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JTextArea;
-import javax.swing.JTextField;
 import javax.swing.WindowConstants;
 
 import org.apache.avro.file.CodecFactory;
@@ -35,10 +34,12 @@ import com.oculusinfo.binning.TileData;
 import com.oculusinfo.binning.TileIndex;
 import com.oculusinfo.binning.io.serialization.TileSerializer;
 import com.oculusinfo.binning.io.serialization.impl.DoubleAvroSerializer;
-import com.oculusinfo.tilegen.binning.LiveStaticTilePyramidIO;
+import com.oculusinfo.binning.util.Pair;
+import com.oculusinfo.tilegen.binning.OnDemandAccumulatorPyramidIO;
 
 public class JuliaLiveTest extends JFrame {
 	private static final long serialVersionUID = 1L;
+	private static final String ID = "julia";
 
 
 
@@ -52,13 +53,16 @@ public class JuliaLiveTest extends JFrame {
 
 
 
-	private SparkContext            _sc;
-	private LiveStaticTilePyramidIO _pyramidIO;
-	private TileSerializer<Double>  _serializer;
+	private JSONObject                   _config;
+	private SparkContext                 _sc;
+	private OnDemandAccumulatorPyramidIO _pyramidIO;
+	private TileSerializer<Double>       _serializer;
 
 
 
 	public JuliaLiveTest () throws IOException, JSONException {
+		setupConfiguration();
+
 		setupSparkContext();
 		setupPyramidIO();
 		setupTileSerializer();
@@ -66,16 +70,7 @@ public class JuliaLiveTest extends JFrame {
 		setupUI();
 	}
 
-	private void setupSparkContext () {
-		SparkConf conf = new SparkConf();
-		conf.setMaster("local[1]");
-		conf.setAppName("Julia live tile testing");
-		JavaSparkContext jsc = new JavaSparkContext(conf);
-		_sc = JavaSparkContext.toSparkContext(jsc);
-		_sc.cancelAllJobs();
-	}
-
-	private void setupPyramidIO () throws IOException, JSONException {
+	private void setupConfiguration () throws IOException, JSONException {
 		String rawConfig = "";
 		String line;
 		InputStream configStream = JuliaLiveTest.class.getResourceAsStream("/layers/julia-layer.json");
@@ -84,19 +79,42 @@ public class JuliaLiveTest extends JFrame {
 			rawConfig += line;
 		configReader.close();
 
-		JSONObject jsonConfig = new JSONObject(rawConfig)
+		_config = new JSONObject(rawConfig)
 			.getJSONArray("layers")
 			.getJSONObject(0)
 			.getJSONObject("data")
 			.getJSONObject("pyramidio")
 			.getJSONObject("data");
+	}
 
+	private void setupSparkContext () throws JSONException {
+		SparkConf conf = new SparkConf();
+		conf.setMaster("spark://hadoop-s1.oculus.local:7077");
+		conf.setAppName("Julia live tile testing");
+		conf.setSparkHome("/opt/spark");
+		conf.setJars(new String[] {
+				"target/tile-generation-0.4-SNAPSHOT.jar",
+				"../binning-utilities/target/binning-utilities-0.4-SNAPSHOT.jar"                        
+			});
+
+		for (String key: JSONObject.getNames(_config)) {
+			if (key.startsWith("spark")) {
+				conf.set(key, _config.getString(key));
+			}
+		}
+
+		JavaSparkContext jsc = new JavaSparkContext(conf);
+		_sc = JavaSparkContext.toSparkContext(jsc);
+		_sc.cancelAllJobs();
+	}
+
+	private void setupPyramidIO () throws IOException, JSONException {
 		Properties config = new Properties();
-		for (String key: JSONObject.getNames(jsonConfig))
-			config.setProperty(key, jsonConfig.getString(key));
+		for (String key: JSONObject.getNames(_config))
+			config.setProperty(key, _config.getString(key));
 
-		_pyramidIO = new LiveStaticTilePyramidIO(_sc);
-		_pyramidIO.initializeForRead("julia", 256, 256, config);
+		_pyramidIO = new OnDemandAccumulatorPyramidIO(_sc);
+		_pyramidIO.initializeForRead(ID, 256, 256, config);
 	}
 
 	private void setupTileSerializer () {
@@ -111,42 +129,34 @@ public class JuliaLiveTest extends JFrame {
 
 		JButton doTiling = new JButton("Retrieve tiles");
 
-		final JTextField partitions = new JTextField();
-		partitions.setEditable(true);
-		if (_pyramidIO.getConsolidationPartitions().isDefined()) {
-			partitions.setText(_pyramidIO.getConsolidationPartitions().get().toString());
-		} else {
-			partitions.setText("");
-		}
 		add(tiles,                      new GridBagConstraints(0, 0, 4, 1, 1.0, 1.0, GridBagConstraints.CENTER, GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0));
 		add(new JLabel(""),             new GridBagConstraints(0, 1, 1, 1, 1.0, 0.0, GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
 		add(new JLabel("Partitions: "), new GridBagConstraints(1, 1, 1, 1, 0.0, 0.0, GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
-		add(partitions,                 new GridBagConstraints(2, 1, 1, 1, 0.5, 0.0, GridBagConstraints.WEST, GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0));
 		add(doTiling,                   new GridBagConstraints(3, 1, 1, 1, 0.0, 0.0, GridBagConstraints.EAST, GridBagConstraints.NONE, new Insets(0, 0, 0, 0), 0, 0));
 
 		doTiling.addActionListener(new ActionListener() {
 				@Override
 				public void actionPerformed (ActionEvent event) {
-					Integer conParts = null;
-					try {
-						conParts = Integer.parseInt(partitions.getText().trim());
-					} catch (NumberFormatException e) {}
-					if (null == conParts) {
-						_pyramidIO.eliminateConsolidationPartitions();
-					} else {
-						_pyramidIO.setConsolidationPartitions(conParts);
+					Pair<ArrayList<TileIndex>, Integer> test= parseIndices(tiles.getText().replace("\n", ""));
+					for (int i=0; i<test.getSecond(); ++i) {
+						testTileRetrieval(test.getFirst());
 					}
-					List<TileIndex> indices = parseIndices(tiles.getText().replace("\n", ""));
-					testTileRetrieval(indices);
 				}
 			});
 	}
 
-	private List<TileIndex> parseIndices (String text) {
-		List<TileIndex> tileList = new ArrayList<>();
+	private Pair<ArrayList<TileIndex>, Integer> parseIndices (String text) {
+		ArrayList<TileIndex> tileList = new ArrayList<>();
 
 		// Parse tile list
-		for (String part: text.split(";")) {
+		String[] parts = text.split("x");
+		int repetitions = 1;
+		String tiles = text;
+		if (2 == parts.length) {
+			repetitions = Integer.parseInt(parts[0].trim());
+			tiles = parts[1];
+		}
+		for (String part: tiles.split(";")) {
 			String[] subParts = part.split(",");
 			if (3 <= subParts.length) {
 				List<Integer> xs = parseIndex(subParts[0].trim());
@@ -158,7 +168,7 @@ public class JuliaLiveTest extends JFrame {
 							tileList.add(new TileIndex(z, x, y));
 			}
 		}
-		return tileList;
+		return new Pair<ArrayList<TileIndex>, Integer>(tileList, repetitions);
 	}
 
 	private List<Integer> parseIndex (String index) {
@@ -192,7 +202,7 @@ public class JuliaLiveTest extends JFrame {
 		System.gc();
 		System.gc();
 		long startTime = System.currentTimeMillis();
-		List<TileData<Double>> tiles = _pyramidIO.readTiles("julia", _serializer, indices);
+		List<TileData<Double>> tiles = _pyramidIO.readTiles(ID, _serializer, indices);
 		long endTime = System.currentTimeMillis();
 		Set<TileIndex> input = new HashSet<>(indices);
 		Set<TileIndex> output = new HashSet<>();

--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/binning/OnDemandAccumulatorPyramidIO.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/binning/OnDemandAccumulatorPyramidIO.scala
@@ -1,0 +1,422 @@
+/*
+ * Copyright (c) 2014 Oculus Info Inc.
+ * http://www.oculusinfo.com/
+ *
+ * Released under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+
+package com.oculusinfo.tilegen.binning
+
+
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.IOException
+import java.lang.{Iterable => JavaIterable}
+import java.lang.{Integer => JavaInt}
+import java.util.{List => JavaList}
+import java.util.Properties
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.{Map => MutableMap}
+import scala.collection.mutable.MutableList
+import scala.collection.mutable.{Set => MutableSet}
+import scala.collection.mutable.Stack
+import scala.reflect.ClassTag
+import scala.util.{Try, Success, Failure}
+
+import org.apache.spark.Accumulable
+import org.apache.spark.AccumulableParam
+import org.apache.spark.SparkContext
+import org.apache.spark.SparkContext._
+import org.apache.spark.rdd.RDD
+import com.oculusinfo.binning.BinIndex
+import com.oculusinfo.binning.TileData
+import com.oculusinfo.binning.TileIndex
+import com.oculusinfo.binning.TilePyramid
+import com.oculusinfo.binning.io.PyramidIO
+import com.oculusinfo.binning.io.serialization.TileSerializer
+import com.oculusinfo.binning.metadata.PyramidMetaData
+import com.oculusinfo.tilegen.datasets.Dataset
+import com.oculusinfo.tilegen.datasets.DatasetFactory
+import com.oculusinfo.tilegen.tiling.analytics.AnalysisDescription
+import org.apache.log4j.Level
+
+
+
+
+/**
+ * This class reads and caches a data set for live queries of its tiles
+ */
+class OnDemandAccumulatorPyramidIO (sc: SparkContext) extends PyramidIO {
+	private val datasets = MutableMap[String, Dataset[_, _, _, _, _]]()
+	private val metaData = MutableMap[String, PyramidMetaData]()
+	private val accStore = new AccumulatorStore
+
+	def getDataset (pyramidId: String) = datasets(pyramidId)
+
+	// Shared in package only for testing purposes
+	private [binning] def debugAccumulatorStore = accStore
+
+	def initializeForWrite (pyramidId: String): Unit = {
+	}
+
+	def writeTiles[T] (pyramidId: String,
+	                   serializer: TileSerializer[T],
+	                   data: JavaIterable[TileData[T]]): Unit =
+		throw new IOException("Can't write raw data")
+
+	def writeMetaData (pyramidId: String,
+	                   metaData: String): Unit =
+		throw new IOException("Can't write raw data")
+
+	def initializeForRead (pyramidId: String,
+	                       width: Int, height: Int,
+	                       dataDescription: Properties): Unit = {
+		if (!datasets.contains(pyramidId)) {
+			datasets.synchronized {
+				if (!datasets.contains(pyramidId)) {
+					if (!dataDescription.stringPropertyNames.contains("oculus.binning.caching.processed"))
+						dataDescription.setProperty("oculus.binning.caching.processed", "true")
+					val newDataset =
+						DatasetFactory.createDataset(sc, dataDescription, Some(width), Some(height))
+					newDataset.getTileAnalytics.map(_.addGlobalAccumulator(sc))
+					newDataset.getDataAnalytics.map(_.addGlobalAccumulator(sc))
+					datasets(pyramidId) = newDataset
+				}
+			}
+		}
+	}
+
+	def readTiles[BT] (pyramidId: String,
+	                   serializer: TileSerializer[BT],
+	                   javaTiles: JavaIterable[TileIndex]): JavaList[TileData[BT]] = {
+		if (!datasets.contains(pyramidId) || null == javaTiles || !javaTiles.iterator.hasNext) {
+			null
+		} else {
+			val tiles = javaTiles.asScala.toArray
+			val dataset = datasets(pyramidId).asInstanceOf[Dataset[_, _, _, _, BT]]
+
+			val results = readTilesAndDataset(pyramidId, serializer, tiles, dataset)
+			updateMetaData(pyramidId, results)
+			results.asJava
+		}
+	}
+
+	def readTilesAndDataset[IT: ClassTag, PT: ClassTag, DT: ClassTag, AT: ClassTag, BT] (
+		pyramidId: String, serializer: TileSerializer[BT],
+		tiles: Array[TileIndex], dataset: Dataset[IT, PT, DT, AT, BT]):
+			Seq[TileData[BT]] =
+	{
+		val analytic = dataset.getBinningAnalytic
+		val tileAnalytics = dataset.getTileAnalytics
+		val dataAnalytics = dataset.getDataAnalytics.asInstanceOf[Option[AnalysisDescription[(IT, PT), DT]]]
+		val xBins = tiles(0).getXBins
+		val yBins = tiles(0).getYBins
+
+
+
+		// Get a map from tile level to a list of tiles on that level, with associated
+		// accumulables.
+		val levels = tiles.map(_.getLevel).toSet
+		val add: (PT, PT) => PT = analytic.aggregate
+
+		val tileData = levels.map(level =>
+			(level,
+			 tiles.filter(tile => level == tile.getLevel).map(tile =>
+				 (tile -> accStore.reserve(sc, add, xBins, yBins))
+			 ).toMap
+			)
+		).toMap
+
+		// Make sure to gather appropriate global metadata
+		tileAnalytics.map(analytic =>
+			levels.map(level => analytic.addLevelAccumulator(sc, level))
+		)
+		dataAnalytics.map(analytic =>
+			levels.map(level => analytic.addLevelAccumulator(sc, level))
+		)
+
+		// Make sure to gather appropriate tile metadata
+		val dataAnalyticAccumulators: Option[Map[TileIndex, TileAccumulableInfo[DT]]] = dataAnalytics.map(da =>
+			{
+				tiles.map(index =>
+					{
+						(index, accStore.reserve(sc, da.analytic.aggregate, 1, 1))
+					}
+				).toMap
+			}
+		)
+		val unitBin = new BinIndex(0, 0)
+
+		// Run over data set, looking for points in those tiles at those levels
+		val indexScheme = dataset.getIndexScheme
+		val pyramid = dataset.getTilePyramid
+		val identity: RDD[(IT, PT, Option[DT])] => RDD[(IT, PT, Option[DT])] =
+			rdd => rdd
+		dataset.transformRDD(identity).foreach{case (index, value, analyticValue) =>
+			{
+				val (x, y) = indexScheme.toCartesian(index)
+
+				tileData.foreach{case (level, tileInfos) =>
+					{
+						val tile = pyramid.rootToTile(x, y, level, xBins, yBins)
+						if (tileInfos.contains(tile)) {
+							val bin = pyramid.rootToBin(x, y, tile)
+							// update bin value
+							tileInfos(tile).accumulable += (bin, value)
+							// update data analytic value
+							dataAnalytics.foreach(da =>
+								{
+									val dataAnalyticValue = da.convert((index, value))
+									val daAccumulable = dataAnalyticAccumulators.get.apply(tile).accumulable
+									daAccumulable += (unitBin, dataAnalyticValue)
+								}
+							)
+						}
+					}
+				}
+			}
+		}
+
+		// We've got aggregates of each tile's data; convert to tiles.
+		val results = tileData.flatMap(_._2).flatMap{case (index, data) =>
+			{
+				if (data.accumulable.value.isEmpty) {
+					Seq[TileData[BT]]()
+				} else {
+					val tile = new TileData[BT](index)
+
+					// Put the proper default in all bins
+					val defaultBinValue =
+						analytic.finish(analytic.defaultProcessedValue)
+					for (x <- 0 until xBins) {
+						for (y <- 0 until yBins) {
+							tile.setBin(x, y, defaultBinValue)
+						}
+					}
+
+					// Put the proper value into each bin
+					data.accumulable.value.foreach{case (bin, value) =>
+						tile.setBin(bin.getX, bin.getY, analytic.finish(value))
+					}
+
+					// Apply data analytics
+					dataAnalytics.map(da =>
+						{
+							val tileData = dataAnalyticAccumulators.get.apply(index).accumulable.value.get(unitBin)
+							tileData.foreach(analyticValue =>
+								{
+									da.accumulate(index, analyticValue)
+									val tileMetaData = da.analytic.toMap(analyticValue)
+									tileMetaData.map{case (key, value) =>
+										tile.setMetaData(key, value)
+									}
+								}
+							)
+						}
+					)
+
+					// Apply tile analytics
+					tileAnalytics.map(analytic =>
+						{
+							// Figure out the value for this tile
+							val analyticValue = analytic.convert(tile)
+							// Add it into any appropriate accumulators
+							analytic.accumulate(tile.getDefinition(), analyticValue)
+							// And store it in the tile's metadata
+							analytic.analytic.toMap(analyticValue).map{case (key, value) =>
+								tile.setMetaData(key, value)
+							}
+						}
+					)
+
+					Seq[TileData[BT]](tile)
+				}
+			}
+		}.toSeq
+
+		// Free up the accumulables we've used
+		tileData.flatMap(_._2).foreach{case (index, data) =>
+			accStore.release(data)
+		}
+
+		println("Read "+results.size+" tiles.")
+		println("\t"+accStore.inUseCount+" accumulators in use")
+		println("\t"+accStore.inUseData+" bins locked in in-use accumulators")
+		println("\t"+accStore.availableCount+" accumulators available")
+		println("\t"+accStore.availableData+" bins size locked in available accumulators")
+
+		results
+	}
+
+	def updateMetaData[BT] (pyramidId: String, tiles: Iterable[TileData[BT]]) = {
+		// Update metadata for these levels
+		val datasetMetaData = getMetaData(pyramidId).get
+		val dataset = datasets(pyramidId).asInstanceOf[Dataset[_, _, _, _, BT]]
+
+		val newDatasetMetaData =
+			new PyramidMetaData(datasetMetaData.getName(),
+			                    datasetMetaData.getDescription(),
+			                    datasetMetaData.getTileSizeX(),
+			                    datasetMetaData.getTileSizeY(),
+			                    datasetMetaData.getScheme(),
+			                    datasetMetaData.getProjection(),
+			                    datasetMetaData.getValidZoomLevels(),
+			                    datasetMetaData.getBounds(),
+			                    null, null)
+		dataset.getTileAnalytics.map(_.applyTo(newDatasetMetaData))
+		dataset.getDataAnalytics.map(_.applyTo(newDatasetMetaData))
+		newDatasetMetaData.addValidZoomLevels(
+			tiles.map(tile =>
+				new JavaInt(tile.getDefinition().getLevel())
+			).toSet.asJava
+		)
+
+		metaData(pyramidId) = newDatasetMetaData
+	}
+
+
+
+	def getTileStream[BT] (pyramidId: String, serializer: TileSerializer[BT],
+	                       tile: TileIndex): InputStream = {
+		val results: JavaList[TileData[BT]] =
+			readTiles(pyramidId, serializer, List[TileIndex](tile).asJava)
+		if (null == results || 0 == results.size || null == results.get(0)) {
+			null
+		} else {
+			val bos = new ByteArrayOutputStream;
+			serializer.serialize(results.get(0), bos);
+			bos.flush
+			bos.close
+			new ByteArrayInputStream(bos.toByteArray)
+		}
+	}
+
+	private def getMetaData (pyramidId: String): Option[PyramidMetaData] = {
+		if (!metaData.contains(pyramidId) || null == metaData(pyramidId))
+			if (datasets.contains(pyramidId))
+				metaData(pyramidId) = datasets(pyramidId).createMetaData(pyramidId)
+		metaData.get(pyramidId)
+	}
+
+	def readMetaData (pyramidId: String): String =
+		getMetaData(pyramidId).map(_.toString).getOrElse(null)
+
+	def removeTiles (id: String, tiles: JavaIterable[TileIndex]  ) : Unit =
+		throw new IOException("removeTiles not currently supported for OnDemandAccumulatorPyramidIO")
+}
+
+
+case class TileAccumulableInfo[PT: ClassTag] (
+	accumulable: Accumulable[MutableMap[BinIndex, PT], (BinIndex, PT)],
+	param: TileAccumulableParam[PT]
+) {}
+
+class TileAccumulableParam[PT] (private var width: Int,
+                                private var height: Int,
+                                private var add: (PT, PT) => PT)
+		extends AccumulableParam[MutableMap[BinIndex, PT], (BinIndex, PT)]
+{
+	def reset (w: Int, h: Int, a: (PT, PT) => PT): Unit = {
+		width = w
+		height = h
+		add = a
+	}
+	def addAccumulator (r: MutableMap[BinIndex, PT], t: (BinIndex, PT)):
+			MutableMap[BinIndex, PT] = {
+		val (index, value) = t
+		r(index) = r.get(index).map(valueR => add(valueR, value)).getOrElse(value)
+		r
+	}
+
+	def addInPlace (r1: MutableMap[BinIndex, PT], r2: MutableMap[BinIndex, PT]):
+			MutableMap[BinIndex, PT] = {
+		r2.foreach{case (index, value2) =>
+			{
+				r1(index) = r1.get(index).map(value1 => add(value1, value2)).getOrElse(value2)
+			}
+		}
+		r1
+	}
+	def zero (initialValue: MutableMap[BinIndex, PT]): MutableMap[BinIndex, PT] =
+		MutableMap[BinIndex, PT]()
+}
+
+class AccumulatorStore {
+	// Make sure functions only work on the client thread that created the store
+	private val origin = Thread.currentThread
+	private val inUse = MutableMap[ClassTag[_], MutableSet[TileAccumulableInfo[_]]]()
+	private val available = MutableMap[ClassTag[_], Stack[TileAccumulableInfo[_]]]()
+
+	// debug info - number of accumulators reserved, in use, etc.
+	def inUseCount = inUse.map(_._2.size).fold(0)(_ + _)
+	def availableCount = available.map(_._2.size).fold(0)(_ + _)
+	def totalCount = inUseCount + availableCount
+
+	// debug info - number of bins of data in reserved, in use, etc. accumulators
+	def inUseData =
+		inUse.map(_._2.map(_.accumulable.value.size).fold(0)(_ + _))
+			.fold(0)(_ + _)
+	def availableData =
+		available.map(_._2.map(_.accumulable.value.size).fold(0)(_ + _))
+			.fold(0)(_ + _)
+	def totalData = inUseData + availableData
+
+	def reserve[PT] (sc: SparkContext,
+	                 add: (PT, PT) => PT,
+	                 xBins: Int,
+	                 yBins: Int)(implicit evidence: ClassTag[PT]): TileAccumulableInfo[PT] = {
+		val info: TileAccumulableInfo[PT] =
+			available.synchronized {
+				if (!available.contains(evidence) || available(evidence).isEmpty) {
+					// None available, create a new one.
+					val param = new TileAccumulableParam[PT](xBins, yBins, add)
+					val accum = sc.accumulable(MutableMap[BinIndex, PT]())(param)
+					new TileAccumulableInfo[PT](accum, param)(evidence)
+				} else {
+					val reusable = available(evidence).pop.asInstanceOf[TileAccumulableInfo[PT]]
+					reusable.param.reset(xBins, yBins, add)
+					reusable
+				}
+			}
+		inUse.synchronized {
+			if (!inUse.contains(evidence)) {
+				inUse(evidence) = MutableSet[TileAccumulableInfo[_]]()
+			}
+		}
+		inUse(evidence) += info
+		info
+	}
+	def release[PT] (info: TileAccumulableInfo[PT])(implicit evidence: ClassTag[PT]): Unit = {
+		inUse(evidence) -= info
+		info.accumulable.setValue(info.param.zero(info.accumulable.value))
+		available.synchronized {
+			if (!available.contains(evidence)) {
+				available(evidence) = Stack[TileAccumulableInfo[_]]()
+			}
+		}
+		available(evidence).push(info)
+	}
+}

--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/datasets/Dataset.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/datasets/Dataset.scala
@@ -46,7 +46,6 @@ import org.apache.spark.streaming.Time
 import com.oculusinfo.binning.TileData
 import com.oculusinfo.binning.TileIndex
 import com.oculusinfo.binning.TilePyramid
-import com.oculusinfo.binning.io.serialization.TileSerializer
 import com.oculusinfo.binning.metadata.PyramidMetaData
 import com.oculusinfo.binning.util.Pair
 import com.oculusinfo.tilegen.tiling.analytics.AnalysisDescription

--- a/tile-generation/src/test/scala/com/oculusinfo/tilegen/datasets/DatasetAnalyticTestSuite.scala
+++ b/tile-generation/src/test/scala/com/oculusinfo/tilegen/datasets/DatasetAnalyticTestSuite.scala
@@ -43,7 +43,7 @@ import org.apache.spark.SharedSparkContext
 import com.oculusinfo.binning.TileData
 import com.oculusinfo.binning.TileIndex
 import com.oculusinfo.binning.io.PyramidIO
-import com.oculusinfo.tilegen.binning.LiveStaticTilePyramidIO
+import com.oculusinfo.tilegen.binning.OnDemandBinningPyramidIO
 import com.oculusinfo.tilegen.tiling.analytics.AnalysisDescriptionTileWrapper
 import com.oculusinfo.tilegen.tiling.analytics.MonolithicAnalysisDescription
 import com.oculusinfo.tilegen.tiling.analytics.NumericMaxTileAnalytic
@@ -54,7 +54,7 @@ import com.oculusinfo.tilegen.tiling.analytics.NumericMinTileAnalytic
 class DatasetAnalyticTestSuite extends FunSuite with SharedSparkContext with BeforeAndAfterAll {
 	val pyramidId: String = "test"
 	var dataFile: File = null
-	var pyramidIo: LiveStaticTilePyramidIO = null
+	var pyramidIo: OnDemandBinningPyramidIO = null
 
 	override def beforeAll (configMap: Map[String, Any]) = {
 		super.beforeAll(configMap)
@@ -90,8 +90,8 @@ class DatasetAnalyticTestSuite extends FunSuite with SharedSparkContext with Bef
 		props.setProperty("oculus.binning.parsing.x.index", "0")
 		props.setProperty("oculus.binning.parsing.y.index", "1")
 		props.setProperty("oculus.binning.parsing.v.index", "2")
-        props.setProperty("oculus.binning.parsing.v.fieldType", "long")
-        props.setProperty("oculus.binning.parsing.v.fieldAggregation", "mean")
+		props.setProperty("oculus.binning.parsing.v.fieldType", "long")
+		props.setProperty("oculus.binning.parsing.v.fieldAggregation", "mean")
 		props.setProperty("oculus.binning.index.type", "cartesian")
 		props.setProperty("oculus.binning.xField", "x")
 		props.setProperty("oculus.binning.yField", "y")
@@ -102,7 +102,7 @@ class DatasetAnalyticTestSuite extends FunSuite with SharedSparkContext with Bef
 		props.setProperty("oculus.binning.analytics.data.0",
 		                  "com.oculusinfo.tilegen.datasets.TestDataAnalytic")
 
-		pyramidIo = new LiveStaticTilePyramidIO(sc)
+		pyramidIo = new OnDemandBinningPyramidIO(sc)
 		pyramidIo.initializeForRead(pyramidId, 4, 4, props)
 	}
 
@@ -182,7 +182,7 @@ class TestTileAnalytic
 
 class TestDataAnalytic
 		extends MonolithicAnalysisDescription[((Double, Double), (Long, Int)), Double] (
-v => {
+	v => {
 		val result = ((v._2._1+1)*(v._2._1+1))
 		result
 	},

--- a/tile-service/src/main/java/com/oculusinfo/tile/init/providers/SparkAwarePyramidIOFactoryProvider.java
+++ b/tile-service/src/main/java/com/oculusinfo/tile/init/providers/SparkAwarePyramidIOFactoryProvider.java
@@ -28,7 +28,7 @@ import com.google.inject.Inject;
 import com.oculusinfo.binning.io.PyramidIO;
 import com.oculusinfo.factory.ConfigurableFactory;
 import com.oculusinfo.tile.init.DelegateFactoryProviderTarget;
-import com.oculusinfo.tile.rest.tile.caching.LiveTilePyramidIOFactory;
+import com.oculusinfo.tile.rest.tile.caching.OnDemandTilePyramidIOFactory;
 import com.oculusinfo.tile.spark.SparkContextProvider;
 
 import java.util.List;
@@ -41,12 +41,12 @@ public class SparkAwarePyramidIOFactoryProvider implements DelegateFactoryProvid
 
 	@Override
 	public ConfigurableFactory<PyramidIO> createFactory (List<String> path) {
-		return new LiveTilePyramidIOFactory(null, path, _contextProvider);
+		return new OnDemandTilePyramidIOFactory(null, path, _contextProvider);
 	}
 	
 	@Override
 	public ConfigurableFactory<PyramidIO> createFactory (ConfigurableFactory<?> parent,
 	                                                     List<String> path) {
-		return new LiveTilePyramidIOFactory(parent, path, _contextProvider);
+		return new OnDemandTilePyramidIOFactory(parent, path, _contextProvider);
 	}
 }

--- a/tile-service/src/main/java/com/oculusinfo/tile/rest/tile/caching/OnDemandTilePyramidIOFactory.java
+++ b/tile-service/src/main/java/com/oculusinfo/tile/rest/tile/caching/OnDemandTilePyramidIOFactory.java
@@ -34,15 +34,15 @@ import com.oculusinfo.binning.io.PyramidIO;
 import com.oculusinfo.binning.io.PyramidIOFactory;
 import com.oculusinfo.factory.ConfigurableFactory;
 import com.oculusinfo.tile.spark.SparkContextProvider;
-import com.oculusinfo.tilegen.binning.LiveStaticTilePyramidIO;
+import com.oculusinfo.tilegen.binning.OnDemandAccumulatorPyramidIO;
 
-public class LiveTilePyramidIOFactory extends ConfigurableFactory<PyramidIO> {
-	private static final Logger LOGGER = LoggerFactory.getLogger(LiveTilePyramidIOFactory.class);
+public class OnDemandTilePyramidIOFactory extends ConfigurableFactory<PyramidIO> {
+	private static final Logger LOGGER = LoggerFactory.getLogger(OnDemandTilePyramidIOFactory.class);
 
 	@Inject
 	private SparkContextProvider _contextProvider;
 
-	public LiveTilePyramidIOFactory (ConfigurableFactory<?> parent, List<String> path, SparkContextProvider contextProvider) {
+	public OnDemandTilePyramidIOFactory (ConfigurableFactory<?> parent, List<String> path, SparkContextProvider contextProvider) {
 		super("live", PyramidIO.class, parent, path);
 		_contextProvider = contextProvider;
 	}
@@ -51,7 +51,7 @@ public class LiveTilePyramidIOFactory extends ConfigurableFactory<PyramidIO> {
 	protected PyramidIO create () {
 		try {
 			JSONObject config = getPropertyValue(PyramidIOFactory.INITIALIZATION_DATA);
-			return new LiveStaticTilePyramidIO(_contextProvider.getSparkContext(config));
+			return new OnDemandAccumulatorPyramidIO(_contextProvider.getSparkContext(config));
 		}
 		catch (Exception e) {
 			LOGGER.error("Error trying to create FileSystemPyramidIO", e);


### PR DESCRIPTION
Make sure it works interchangably with RDDBinner-based tiling (but leave non-on-demand tests using RDDBinner-based tiling, so as to exercise RDDBinner too).  
Use accumulator-based tiling in on-demand demo and tile service in general.

I've also renamed on-demand tiling classes to OnDemand from Live, which was easily confused with Streaming.

There may be a memory leak in this - I've gone through in the profiler, and can't find one, but I've a test case that runs out of memory with accumulator-based on-demand tiling, and doesn't with RDDBinner-based.
