### PR TITLE
Make it easier to run the tile service in debug mode ...

### DIFF
--- a/tile-service/src/main/java/com/oculusinfo/tile/spark/SparkContextProviderImpl.java
+++ b/tile-service/src/main/java/com/oculusinfo/tile/spark/SparkContextProviderImpl.java
@@ -24,11 +24,12 @@
 package com.oculusinfo.tile.spark;
 
 
-import com.google.inject.Inject;
-import com.google.inject.Singleton;
-import com.google.inject.name.Named;
-import com.oculusinfo.tile.ServletLifecycleListener;
-import com.oculusinfo.tile.TileServiceConfiguration;
+import java.io.File;
+import java.io.FilenameFilter;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.servlet.ServletContextEvent;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
@@ -39,10 +40,11 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.LoggerFactory;
 
-import javax.servlet.ServletContextEvent;
-
-import java.util.ArrayList;
-import java.util.List;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.inject.name.Named;
+import com.oculusinfo.tile.ServletLifecycleListener;
+import com.oculusinfo.tile.TileServiceConfiguration;
 
 
 
@@ -124,8 +126,24 @@ public class SparkContextProviderImpl implements SparkContextProvider {
 	}
 
 	private String getJarPathForClass (Class<?> type) {
-		return type.getProtectionDomain().getCodeSource().getLocation()
-			.getPath();
+	    String location = type.getProtectionDomain().getCodeSource().getLocation().getPath();
+	    // This whole "classes" case is to account for when we're trying to 
+	    // run from an IDE, which automatically adds projects to the class 
+	    // path.  we need class directories replaced with jars.  Note that 
+	    // this means the program won't work unless the project as been 
+	    // packaged; this was always the case, but is more explicitly so now.
+	    if (location.endsWith("classes/")) {
+	        File target = new File(location).getParentFile();
+	        File[] children = target.listFiles(new FilenameFilter() {
+                @Override
+                public boolean accept (File dir, String name) {
+                    return name.endsWith(".jar") && !name.endsWith("sources.jar") && !name.endsWith("javadoc.jar") && !name.endsWith("tests.jar");
+                }
+            });
+	        if (null != children && 1 == children.length)
+	            location = children[0].toURI().getPath();
+	    }
+	    return location;
 	}
 
 	@Override


### PR DESCRIPTION
... from an IDE - try to alleviate the need to manually add jars to the spark context.

This should have no effect on non-debug-mode runs.
