### PR TITLE
configurable rest endpoint for layer service tms property.

### DIFF
--- a/tile-service/src/main/java/com/oculusinfo/tile/rendering/LayerConfiguration.java
+++ b/tile-service/src/main/java/com/oculusinfo/tile/rendering/LayerConfiguration.java
@@ -72,6 +72,7 @@ public class LayerConfiguration extends ConfigurableFactory<LayerConfiguration> 
     public static final List<String> DATA_PATH = Collections.unmodifiableList( Arrays.asList( "private", "data" ) );
     public static final List<String> PYRAMID_IO_PATH = Collections.unmodifiableList( Arrays.asList( "private", "data","pyramidio" ) );
 	public static final List<String> SERIALIZER_PATH = Collections.unmodifiableList( Arrays.asList( "private", "data","serializer" ) );
+    public static final List<String> REST_ENDPOINT_PATH = Collections.unmodifiableList( Arrays.asList( "private" ) );
 
     public static final String DEFAULT_VERSION = "v1.0";
 
@@ -81,6 +82,9 @@ public class LayerConfiguration extends ConfigurableFactory<LayerConfiguration> 
     public static final StringProperty DATA_ID = new StringProperty("id",
         "The ID of the data source of the layer; exact format depends on how the layer is stored.",
         null);
+    public static final StringProperty REST_ENDPOINT = new StringProperty("restEndpoint",
+	    "The REST endpoint used for the layer, defaults to 'tile'",
+	    "tile");
 	public static final IntegerProperty COARSENESS = new IntegerProperty("coarseness",
 	    "Used by the standard heatmap renderer to allow the client to specify getting coarser tiles than needed, for efficiency (if needed)",
 	    1);
@@ -142,13 +146,13 @@ public class LayerConfiguration extends ConfigurableFactory<LayerConfiguration> 
 		super( name, LayerConfiguration.class, parent, path );
 
 		addProperty(LAYER_ID);
+        addProperty(REST_ENDPOINT, REST_ENDPOINT_PATH);
         addProperty(OUTPUT_WIDTH);
 		addProperty(OUTPUT_HEIGHT);
         addProperty(DATA_ID, DATA_PATH);
 		addProperty(COARSENESS, RENDERER_PATH);
 		addProperty(RANGE_MIN, RENDERER_PATH);
 		addProperty(RANGE_MAX, RENDERER_PATH);
-
 		addProperty(TILE_COORDINATE);
 		addProperty(LEVEL_MINIMUMS);
 		addProperty(LEVEL_MAXIMUMS);

--- a/tile-service/src/main/java/com/oculusinfo/tile/rest/layer/LayerResource.java
+++ b/tile-service/src/main/java/com/oculusinfo/tile/rest/layer/LayerResource.java
@@ -66,6 +66,8 @@ public class LayerResource extends ApertureServerResource {
         try {
             // full layer config
             JSONObject layerConfig = JsonUtilities.deepClone( _service.getLayerJSON( layerId ) );
+            // get layer config factory
+            LayerConfiguration config = _service.getLayerConfiguration( layerId, null );
             // we only need public section
             JSONObject layer = layerConfig.getJSONObject("public");
             // append id
@@ -80,7 +82,6 @@ public class LayerResource extends ApertureServerResource {
             JSONObject metaData = JsonUtilities.deepClone( metaDataPyramid.getRawData() );
             // try to add images per tile to meta
             try {
-                LayerConfiguration config = _service.getLayerConfiguration( layerId, null );
                 TileDataImageRenderer renderer = config.produce( TileDataImageRenderer.class );
                 if ( null != renderer ) {
                     metaData.put("imagesPerTile", renderer.getNumberOfImagesPerTile( metaDataPyramid ));
@@ -89,9 +90,10 @@ public class LayerResource extends ApertureServerResource {
                 // If we have to skip images per tile, it's not a huge deal
                 LOGGER.warn("Couldn't determine images per tile for layer {}", layerId, e);
             }
+            // add meta data
             layer.put("meta", metaData );
-            layer.put("tms", host + "tile/");
-            layer.put("apertureservice", "/tile/");
+            // set tms url with correct endpoint
+            layer.put("tms", host + config.getPropertyValue( LayerConfiguration.REST_ENDPOINT ) + "/");
             return layer;
         } catch (JSONException e) {
             throw new JSONException( "Bad layer request, layer " + layerId + " does not exist" );


### PR DESCRIPTION
Added 'restEndPoint' config attribute to override '/tiles' service endpoint in tms attribute returned from layer service.
