### PR TITLE
Separating rendering logic from config processing logic

### DIFF
--- a/tile-service/src/main/java/com/oculusinfo/tile/rendering/impl/DoubleListHeatMapImageRenderer.java
+++ b/tile-service/src/main/java/com/oculusinfo/tile/rendering/impl/DoubleListHeatMapImageRenderer.java
@@ -100,8 +100,9 @@ public class DoubleListHeatMapImageRenderer implements TileDataImageRenderer {
             TileIndex index,
             int outputWidth,
             int outputHeight,
-            int rangeMax,
             int rangeMin,
+            int rangeMax,
+            double minimumValue,
             double maximumValue,
             TileIndex scaleLevelIndex,
             ValueTransformer<Double> t,
@@ -113,8 +114,8 @@ public class DoubleListHeatMapImageRenderer implements TileDataImageRenderer {
 
         int[] rgbArray = new int[outputWidth * outputHeight];
 
-        double scaledLevelMaxFreq = t.transform(maximumValue) * rangeMax / 100;
-        double scaledLevelMinFreq = t.transform(maximumValue) * rangeMin / 100;
+        double scaledLevelMinFreq = t.transform(maximumValue)*rangeMin/100;
+        double scaledLevelMaxFreq = t.transform(maximumValue)*rangeMax/100;
 
         @SuppressWarnings("unchecked")
         TileData<List<Double>> transformedContents = tileTransformer.transform(data);
@@ -199,6 +200,7 @@ public class DoubleListHeatMapImageRenderer implements TileDataImageRenderer {
             int rangeMin = config.getPropertyValue(LayerConfiguration.RANGE_MIN);
             int coarseness = config.getPropertyValue(LayerConfiguration.COARSENESS);
             double maximumValue = getLevelExtrema(config).getSecond();
+            double minimumValue = getLevelExtrema(config).getFirst();
 
             @SuppressWarnings("unchecked")
             ValueTransformer<Double> t = config.produce(ValueTransformer.class);
@@ -240,7 +242,7 @@ public class DoubleListHeatMapImageRenderer implements TileDataImageRenderer {
               return null;
             }
 
-            renderToBuffer(index, outputWidth, outputHeight, rangeMax, rangeMin, maximumValue, scaleLevelIndex, t, tileDatas.get(0), tileTransformer, colorRamp, bi);
+            renderToBuffer(index, outputWidth, outputHeight, rangeMin, rangeMax, minimumValue, maximumValue, scaleLevelIndex, t, tileDatas.get(0), tileTransformer, colorRamp, bi);
             return bi;
         } catch (Exception e) {
             LOGGER.error("Tile error: " + layerId + ":" + index, e);

--- a/tile-service/src/main/java/com/oculusinfo/tile/rendering/impl/DoublesImageRenderer.java
+++ b/tile-service/src/main/java/com/oculusinfo/tile/rendering/impl/DoublesImageRenderer.java
@@ -86,8 +86,9 @@ public class DoublesImageRenderer implements TileDataImageRenderer {
       TileIndex index,
       int outputWidth,
       int outputHeight,
-      int rangeMax,
       int rangeMin,
+      int rangeMax,
+      double minimumValue,
       double maximumValue,
       TileIndex scaleLevelIndex,
       ValueTransformer<Double> t,
@@ -97,8 +98,8 @@ public class DoublesImageRenderer implements TileDataImageRenderer {
   ) throws Exception {
     int[] rgbArray = new int[outputWidth * outputHeight];
 
-    double scaledLevelMaxFreq = t.transform(maximumValue) * rangeMax / 100;
-    double scaledLevelMinFreq = t.transform(maximumValue) * rangeMin / 100;
+    double scaledLevelMinFreq = t.transform(maximumValue)*rangeMin/100;
+    double scaledLevelMaxFreq = t.transform(maximumValue)*rangeMax/100;
 
     int xBins = data.getDefinition().getXBins();
     int yBins = data.getDefinition().getYBins();
@@ -172,13 +173,10 @@ public class DoublesImageRenderer implements TileDataImageRenderer {
 			int rangeMin = config.getPropertyValue(LayerConfiguration.RANGE_MIN);
 			int coarseness = config.getPropertyValue(LayerConfiguration.COARSENESS);
 			double maximumValue = getLevelExtrema(config).getSecond();
+      double minimumValue = getLevelExtrema(config).getFirst();
 
       @SuppressWarnings("unchecked")
 			ValueTransformer<Double> t = config.produce(ValueTransformer.class);
-			int[] rgbArray = new int[outputWidth*outputHeight];
-
-			double scaledLevelMaxFreq = t.transform(maximumValue)*rangeMax/100;
-			double scaledLevelMinFreq = t.transform(maximumValue)*rangeMin/100;
 
 			int coarsenessFactor = (int)Math.pow(2, coarseness - 1);
 
@@ -214,7 +212,7 @@ public class DoublesImageRenderer implements TileDataImageRenderer {
 
 			TileData<Double> data = tileDatas.get(0);
       BufferedImage bi = new BufferedImage(outputWidth, outputHeight, BufferedImage.TYPE_INT_ARGB);
-      renderToBuffer(index, outputWidth, outputHeight, rangeMax, rangeMin, maximumValue, scaleLevelIndex, t, data, colorRamp, bi);
+      renderToBuffer(index, outputWidth, outputHeight, rangeMin, rangeMax, minimumValue, maximumValue, scaleLevelIndex, t, data, colorRamp, bi);
       return bi;
 		} catch (Exception e) {
 			LOGGER.debug("Tile is corrupt: " + layerId + ":" + index);


### PR DESCRIPTION
Separated rendering logic from config processing logic in a couple of heatmap renderers.

Note that I've included a double minimumValue parameter in both renderToBuffer functions which, I assume, is needed for calculating scaledLevelMinFreq and scaledLevelMaxFreq in the case where minimumValue is not 0. I noticed that this is not currently the way in which these scaled values are being calculated, and I'm wondering if that is a bug (https://github.com/oculusinfo/aperture-tiles/issues/71). If it is, it's probably worth fixing in a different PR (and probably by someone more knowledgable than me), so I undid my attempt to fix it here (hence the "undoing last commit" comment).
