### PR TITLE
Add support for building a subset of projects

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 buildType=cdh4.6.0
+buildProjects=all
 
 # While performance is better when the Gradle is run as a daemon, it results
 # in Jetty being pulled in, and leads to the javax.servlet conflicts that get detailed

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,11 +1,20 @@
-// List of include sub-projects
-include 'math-utilities',
+// tile generation modules
+ext.tileGenProjects = [
+		'math-utilities',
+		'geometric-utilities',
+		'binning-utilities',
+		'tile-generation',
+		'tile-packaging'
+] as Set
+
+// tile client/server Projects
+ext.clientServerProjects = [
+		'math-utilities',
 		'geometric-utilities',
 		'binning-utilities',
 		'tile-generation',
 		'spark-tile-utilities',
 		'tile-service',
-		'tile-packaging',
 		'annotation-service',
 		'tile-client',
 		'tile-client-template',
@@ -13,3 +22,31 @@ include 'math-utilities',
 		'tile-examples:julia-demo-live',
 		'tile-examples:twitter-topics:twitter-topics-utilities',
 		'tile-examples:twitter-topics:twitter-topics-client'
+] as Set
+
+// Projects used for live tiling
+ext.liveTileGenProjects = ['tile-service', 'spark-tile-utilities'] as Set
+liveTileGenProjects.addAll(tileGenProjects)
+liveTileGenProjects.remove('tile-packaging')
+
+ext.projects = ""
+switch (buildProjects) {
+	case "tileGeneration":
+		ext.projects = tileGenProjects
+		break
+	case "clientServer":
+		ext.projects = clientServerProjects
+		break
+	case "liveTiling":
+		ext.projects = liveTileGenProjects
+		break
+	case "all":
+		ext.projects = tileGenProjects + clientServerProjects
+		break
+	default:
+		throw new StopExecutionException("Unsupported build type '$buildProjects' specified")
+}
+
+// List of include sub-projects
+projects.each { projectName -> include projectName }
+


### PR DESCRIPTION
Add a new 'buildProjects" property to settings to allow building a subset of projects.  Useful for cases like working on tile generation, where the expensive WAR task doesn't need to be run.

refs #8687
