### PR TITLE
Add user name and sentiment to Twitter Topic recent tweets

### DIFF
--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/AvroSchemaComposer.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/AvroSchemaComposer.java
@@ -137,8 +137,13 @@ public class AvroSchemaComposer {
 	/** Load a schema via the class-loader resource mechanism. **/
 	public AvroSchemaComposer addResource (String path) throws IOException {
 		try {
-			add(AvroSchemaComposer.class.getClassLoader()
-			    .getResourceAsStream(path));
+			// Try with the system class loader first and use the current class loader if that
+			// fails.
+			InputStream stream = AvroSchemaComposer.class.getClassLoader().getResourceAsStream(path);
+			if (stream == null) {
+				stream = getClass().getResourceAsStream(path);
+			}
+			add(stream);
 		} catch (Exception e) {
 			throw new RuntimeException("Error loading schema " + path,
 			                           e.getCause());

--- a/tile-examples/twitter-topics/twitter-topics-utilities/build.gradle
+++ b/tile-examples/twitter-topics/twitter-topics-utilities/build.gradle
@@ -13,6 +13,13 @@ test << {
 	}
 }
 
+// Turn on test logging regardless of gradle log level
+test {
+	testLogging {
+		events "passed", "skipped", "failed", "standardOut", "standardError"
+	}
+}
+
 // By default the Gradle scala plugin builds java code before scala code.  This leads to problems
 // in our setup because the scala code in this project is used by the java code (causing 
 // compile errors).  We force the plugin to use an empty source set for java, and then set the
@@ -34,5 +41,6 @@ sourceSets {
 dependencies {
 	compile project(":tile-generation")
 	compile project(":tile-service")
-	testCompile "org.scalatest:scalatest_$dependencyScalaVersion:1.9.1"	
+	testCompile "org.scalatest:scalatest_$dependencyScalaVersion:1.9.1"
+	testCompile "junit:junit:4.8.1"
 }

--- a/tile-examples/twitter-topics/twitter-topics-utilities/src/main/java/com/oculusinfo/twitter/binning/RecentTweet.java
+++ b/tile-examples/twitter-topics/twitter-topics-utilities/src/main/java/com/oculusinfo/twitter/binning/RecentTweet.java
@@ -1,6 +1,32 @@
+/*
+ * Copyright (c) 2015 Oculus Info Inc.
+ * http://www.oculusinfo.com/
+ *
+ * Released under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.oculusinfo.twitter.binning;
 
-public class RecentTweet {
+import java.io.Serializable;
+
+public class RecentTweet implements Serializable {
 	private final String text;
 	private final long time;
 	private final String user;

--- a/tile-examples/twitter-topics/twitter-topics-utilities/src/main/java/com/oculusinfo/twitter/binning/RecentTweet.java
+++ b/tile-examples/twitter-topics/twitter-topics-utilities/src/main/java/com/oculusinfo/twitter/binning/RecentTweet.java
@@ -4,13 +4,11 @@ public class RecentTweet {
 	private final String text;
 	private final long time;
 	private final String user;
-	private final String sentiment;
 
-	public RecentTweet(String text, long time, String user, String sentiment) {
+	public RecentTweet(String text, long time, String user) {
 		this.text = text;
 		this.time = time;
 		this.user = user;
-		this.sentiment = sentiment;
 	}
 
 	public String getText() {
@@ -25,10 +23,6 @@ public class RecentTweet {
 		return user;
 	}
 
-	public String getSentiment() {
-		return sentiment;
-	}
-
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
@@ -37,7 +31,6 @@ public class RecentTweet {
 		RecentTweet that = (RecentTweet) o;
 
 		if (time != that.time) return false;
-		if (sentiment != null ? !sentiment.equals(that.sentiment) : that.sentiment != null) return false;
 		if (text != null ? !text.equals(that.text) : that.text != null) return false;
 		if (user != null ? !user.equals(that.user) : that.user != null) return false;
 
@@ -49,7 +42,6 @@ public class RecentTweet {
 		int result = text != null ? text.hashCode() : 0;
 		result = 31 * result + (int) (time ^ (time >>> 32));
 		result = 31 * result + (user != null ? user.hashCode() : 0);
-		result = 31 * result + (sentiment != null ? sentiment.hashCode() : 0);
 		return result;
 	}
 }

--- a/tile-examples/twitter-topics/twitter-topics-utilities/src/main/java/com/oculusinfo/twitter/binning/RecentTweet.java
+++ b/tile-examples/twitter-topics/twitter-topics-utilities/src/main/java/com/oculusinfo/twitter/binning/RecentTweet.java
@@ -1,0 +1,55 @@
+package com.oculusinfo.twitter.binning;
+
+public class RecentTweet {
+	private final String text;
+	private final long time;
+	private final String user;
+	private final String sentiment;
+
+	public RecentTweet(String text, long time, String user, String sentiment) {
+		this.text = text;
+		this.time = time;
+		this.user = user;
+		this.sentiment = sentiment;
+	}
+
+	public String getText() {
+		return text;
+	}
+
+	public long getTime() {
+		return time;
+	}
+
+	public String getUser() {
+		return user;
+	}
+
+	public String getSentiment() {
+		return sentiment;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		RecentTweet that = (RecentTweet) o;
+
+		if (time != that.time) return false;
+		if (sentiment != null ? !sentiment.equals(that.sentiment) : that.sentiment != null) return false;
+		if (text != null ? !text.equals(that.text) : that.text != null) return false;
+		if (user != null ? !user.equals(that.user) : that.user != null) return false;
+
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		int result = text != null ? text.hashCode() : 0;
+		result = 31 * result + (int) (time ^ (time >>> 32));
+		result = 31 * result + (user != null ? user.hashCode() : 0);
+		result = 31 * result + (sentiment != null ? sentiment.hashCode() : 0);
+		return result;
+	}
+}

--- a/tile-examples/twitter-topics/twitter-topics-utilities/src/main/java/com/oculusinfo/twitter/binning/RecentTweet.java
+++ b/tile-examples/twitter-topics/twitter-topics-utilities/src/main/java/com/oculusinfo/twitter/binning/RecentTweet.java
@@ -4,11 +4,13 @@ public class RecentTweet {
 	private final String text;
 	private final long time;
 	private final String user;
+	private final String sentiment;
 
-	public RecentTweet(String text, long time, String user) {
+	public RecentTweet(String text, long time, String user, String sentiment) {
 		this.text = text;
 		this.time = time;
 		this.user = user;
+		this.sentiment = sentiment;
 	}
 
 	public String getText() {
@@ -23,6 +25,10 @@ public class RecentTweet {
 		return user;
 	}
 
+	public String getSentiment() {
+		return sentiment;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) return true;
@@ -31,6 +37,7 @@ public class RecentTweet {
 		RecentTweet that = (RecentTweet) o;
 
 		if (time != that.time) return false;
+		if (sentiment != null ? !sentiment.equals(that.sentiment) : that.sentiment != null) return false;
 		if (text != null ? !text.equals(that.text) : that.text != null) return false;
 		if (user != null ? !user.equals(that.user) : that.user != null) return false;
 
@@ -42,6 +49,7 @@ public class RecentTweet {
 		int result = text != null ? text.hashCode() : 0;
 		result = 31 * result + (int) (time ^ (time >>> 32));
 		result = 31 * result + (user != null ? user.hashCode() : 0);
+		result = 31 * result + (sentiment != null ? sentiment.hashCode() : 0);
 		return result;
 	}
 }

--- a/tile-examples/twitter-topics/twitter-topics-utilities/src/main/java/com/oculusinfo/twitter/binning/TwitterDemoTopicRecord.java
+++ b/tile-examples/twitter-topics/twitter-topics-utilities/src/main/java/com/oculusinfo/twitter/binning/TwitterDemoTopicRecord.java
@@ -317,8 +317,8 @@ public class TwitterDemoTopicRecord implements Serializable {
 			RecentTweet rt = _recentTweets.get(i);
 			if (i > 0)
 				result += ", ";
-			result += "(" + escapeString(rt.getText()) + ", " + rt.getTime()
-					+ ")";
+			result += "(" + escapeString(rt.getText()) + ", " + rt.getTime() + ", " + escapeString(rt.getUser()) + ", "
+					+ escapeString(rt.getSentiment()) + ")";
 		}
 		result += "], endTimeSecs: " + _endTimeSecs + "}";
 		return result;
@@ -371,10 +371,18 @@ public class TwitterDemoTopicRecord implements Serializable {
 			String tweet = unescapeString(value.substring(0, end));
 
 			value = eat(value.substring(end), ", ");
-			end = value.indexOf(")");
+			end = value.indexOf(",");
 			long tweetCount = Long.parseLong(value.substring(0, end));
 
-			recentTweets.add(new RecentTweet(tweet, tweetCount, "", ""));
+			value = eat(value.substring(end), ", ");
+			end = value.indexOf(",");
+			String user = unescapeString(value.substring(0, end));
+
+			value = eat(value.substring(end), ", ");
+			end = value.indexOf(")");
+			String sentiment = unescapeString(value.substring(0, end));
+
+			recentTweets.add(new RecentTweet(tweet, tweetCount, user, sentiment));
 
 			value = value.substring(end + 1);
 			if (value.startsWith(", "))

--- a/tile-examples/twitter-topics/twitter-topics-utilities/src/main/java/com/oculusinfo/twitter/binning/TwitterDemoTopicRecord.java
+++ b/tile-examples/twitter-topics/twitter-topics-utilities/src/main/java/com/oculusinfo/twitter/binning/TwitterDemoTopicRecord.java
@@ -31,8 +31,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 
-import com.oculusinfo.factory.util.Pair;
-
 public class TwitterDemoTopicRecord implements Serializable {
 	private static final long serialVersionUID = 1L;	//NOTE:  using default serialVersion ID
 	

--- a/tile-examples/twitter-topics/twitter-topics-utilities/src/main/java/com/oculusinfo/twitter/binning/TwitterDemoTopicRecord.java
+++ b/tile-examples/twitter-topics/twitter-topics-utilities/src/main/java/com/oculusinfo/twitter/binning/TwitterDemoTopicRecord.java
@@ -31,6 +31,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 
+import com.oculusinfo.binning.util.Pair;
+
 public class TwitterDemoTopicRecord implements Serializable {
 	private static final long serialVersionUID = 1L;	//NOTE:  using default serialVersion ID
 	

--- a/tile-examples/twitter-topics/twitter-topics-utilities/src/main/java/com/oculusinfo/twitter/binning/TwitterDemoTopicRecord.java
+++ b/tile-examples/twitter-topics/twitter-topics-utilities/src/main/java/com/oculusinfo/twitter/binning/TwitterDemoTopicRecord.java
@@ -31,8 +31,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
 
-import com.oculusinfo.binning.util.Pair;
-
 public class TwitterDemoTopicRecord implements Serializable {
 	private static final long serialVersionUID = 1L;	//NOTE:  using default serialVersion ID
 	

--- a/tile-examples/twitter-topics/twitter-topics-utilities/src/main/java/com/oculusinfo/twitter/binning/TwitterTopicAvroSerializer.java
+++ b/tile-examples/twitter-topics/twitter-topics-utilities/src/main/java/com/oculusinfo/twitter/binning/TwitterTopicAvroSerializer.java
@@ -32,6 +32,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.file.CodecFactory;
 
 import com.oculusinfo.binning.io.serialization.GenericAvroArraySerializer;
+import com.oculusinfo.binning.util.Pair;
 import com.oculusinfo.binning.util.TypeDescriptor;
 
 
@@ -84,6 +85,7 @@ extends GenericAvroArraySerializer<TwitterDemoTopicRecord> {
             elt.put("tweet", rawElt.getText());
             elt.put("time", rawElt.getTime());
 	        elt.put("user", rawElt.getUser());
+	        elt.put("sentiment", rawElt.getSentiment());
             result.add(elt);
         }
         return result;

--- a/tile-examples/twitter-topics/twitter-topics-utilities/src/main/java/com/oculusinfo/twitter/binning/TwitterTopicAvroSerializer.java
+++ b/tile-examples/twitter-topics/twitter-topics-utilities/src/main/java/com/oculusinfo/twitter/binning/TwitterTopicAvroSerializer.java
@@ -52,13 +52,13 @@ extends GenericAvroArraySerializer<TwitterDemoTopicRecord> {
         return "twitterTopicEntry.avsc";
     }
 
-    private List<Pair<String, Long>> recentListTOJava (GenericRecord entry) {
+    private List<RecentTweet> recentListTOJava(GenericRecord entry) {
         @SuppressWarnings("unchecked")
         GenericData.Array<GenericRecord> values = (GenericData.Array<GenericRecord>) entry.get("recentTweets");
-        List<Pair<String, Long>> results = new ArrayList<>();
+        List<RecentTweet> results = new ArrayList<>();
         for (GenericRecord value: values) {
-            results.add(new Pair<String, Long>(value.get("tweet").toString(),
-                                               (Long) value.get("time")));
+            results.add(new RecentTweet(value.get("tweet").toString(),
+		            (Long) value.get("time"), "", ""));
         }
         return results;
     }
@@ -76,14 +76,14 @@ extends GenericAvroArraySerializer<TwitterDemoTopicRecord> {
         								(Long)entry.get("endTimeSecs"));
     }
     
-    private List<GenericRecord> recentListToAvro (Schema mainSchema, List<Pair<String, Long>> elts) {
+    private List<GenericRecord> recentListToAvro (Schema mainSchema, List<RecentTweet> elts) {
         Schema eltSchema = mainSchema.getField("recentTweets").schema().getElementType();
         List<GenericRecord> result = new ArrayList<>();
         for (int i=0; i < elts.size(); ++i) {
             GenericRecord elt = new GenericData.Record(eltSchema);
-            Pair<String, Long> rawElt = elts.get(i);
-            elt.put("tweet", rawElt.getFirst());
-            elt.put("time", rawElt.getSecond());
+            RecentTweet rawElt = elts.get(i);
+            elt.put("tweet", rawElt.getText());
+            elt.put("time", rawElt.getTime());
             result.add(elt);
         }
         return result;

--- a/tile-examples/twitter-topics/twitter-topics-utilities/src/main/java/com/oculusinfo/twitter/binning/TwitterTopicAvroSerializer.java
+++ b/tile-examples/twitter-topics/twitter-topics-utilities/src/main/java/com/oculusinfo/twitter/binning/TwitterTopicAvroSerializer.java
@@ -32,7 +32,6 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.file.CodecFactory;
 
 import com.oculusinfo.binning.io.serialization.GenericAvroArraySerializer;
-import com.oculusinfo.factory.util.Pair;
 import com.oculusinfo.binning.util.TypeDescriptor;
 
 
@@ -85,7 +84,6 @@ extends GenericAvroArraySerializer<TwitterDemoTopicRecord> {
             elt.put("tweet", rawElt.getText());
             elt.put("time", rawElt.getTime());
 	        elt.put("user", rawElt.getUser());
-	        elt.put("sentiment", rawElt.getSentiment());
             result.add(elt);
         }
         return result;

--- a/tile-examples/twitter-topics/twitter-topics-utilities/src/main/java/com/oculusinfo/twitter/binning/TwitterTopicAvroSerializer.java
+++ b/tile-examples/twitter-topics/twitter-topics-utilities/src/main/java/com/oculusinfo/twitter/binning/TwitterTopicAvroSerializer.java
@@ -32,7 +32,6 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.file.CodecFactory;
 
 import com.oculusinfo.binning.io.serialization.GenericAvroArraySerializer;
-import com.oculusinfo.binning.util.Pair;
 import com.oculusinfo.binning.util.TypeDescriptor;
 
 

--- a/tile-examples/twitter-topics/twitter-topics-utilities/src/main/java/com/oculusinfo/twitter/binning/TwitterTopicAvroSerializer.java
+++ b/tile-examples/twitter-topics/twitter-topics-utilities/src/main/java/com/oculusinfo/twitter/binning/TwitterTopicAvroSerializer.java
@@ -58,7 +58,7 @@ extends GenericAvroArraySerializer<TwitterDemoTopicRecord> {
         List<RecentTweet> results = new ArrayList<>();
         for (GenericRecord value: values) {
             results.add(new RecentTweet(value.get("tweet").toString(),
-		            (Long) value.get("time"), "", ""));
+		            (Long) value.get("time"), (String) value.get("user"), (String) value.get("sentiment")));
         }
         return results;
     }
@@ -84,6 +84,8 @@ extends GenericAvroArraySerializer<TwitterDemoTopicRecord> {
             RecentTweet rawElt = elts.get(i);
             elt.put("tweet", rawElt.getText());
             elt.put("time", rawElt.getTime());
+	        elt.put("user", rawElt.getUser());
+	        elt.put("sentiment", rawElt.getSentiment());
             result.add(elt);
         }
         return result;

--- a/tile-examples/twitter-topics/twitter-topics-utilities/src/main/resources/twitterTopicEntry.avsc
+++ b/tile-examples/twitter-topics/twitter-topics-utilities/src/main/resources/twitterTopicEntry.avsc
@@ -24,8 +24,8 @@
                    "type": "record",
                    "fields": [
                        {"name": "tweet", "type": "string"},
-                       {"name": "time", "type": "long"}
-                       {"name": "user", "type": "string"}
+                       {"name": "time", "type": "long"},
+                       {"name": "user", "type": "string"},
                        {"name": "sentiment", "type": "string"}
                    ]
                   }

--- a/tile-examples/twitter-topics/twitter-topics-utilities/src/main/resources/twitterTopicEntry.avsc
+++ b/tile-examples/twitter-topics/twitter-topics-utilities/src/main/resources/twitterTopicEntry.avsc
@@ -25,6 +25,8 @@
                    "fields": [
                        {"name": "tweet", "type": "string"},
                        {"name": "time", "type": "long"}
+                       {"name": "user", "type": "string"}
+                       {"name": "sentiment", "type": "string"}
                    ]
                   }
                  },

--- a/tile-examples/twitter-topics/twitter-topics-utilities/src/main/scala/com/oculusinfo/twitter/tilegen/TwitterTopicRecordParser.scala
+++ b/tile-examples/twitter-topics/twitter-topics-utilities/src/main/scala/com/oculusinfo/twitter/tilegen/TwitterTopicRecordParser.scala
@@ -108,7 +108,7 @@ class TwitterTopicRecordParser (endTimeSecs: Long) {
 
     if ((endTimeSecs - time > 0L) && (endTimeSecs - time <= 2678400L)) {
     	// tweet time is valid time interva (i.e., within 1 month prior to endTime)    
-	    val textTime = new RecentTweet(recordLine.text, time, recordLine.userName)
+	    val textTime = new RecentTweet(recordLine.text, time, recordLine.userName, "")
 
 	    val newRecordsMap =
 	    	recordLine.topics

--- a/tile-examples/twitter-topics/twitter-topics-utilities/src/main/scala/com/oculusinfo/twitter/tilegen/TwitterTopicRecordParser.scala
+++ b/tile-examples/twitter-topics/twitter-topics-utilities/src/main/scala/com/oculusinfo/twitter/tilegen/TwitterTopicRecordParser.scala
@@ -108,7 +108,7 @@ class TwitterTopicRecordParser (endTimeSecs: Long) {
 
     if ((endTimeSecs - time > 0L) && (endTimeSecs - time <= 2678400L)) {
     	// tweet time is valid time interva (i.e., within 1 month prior to endTime)    
-	    val textTime = new RecentTweet(recordLine.text, time, recordLine.userName, "")
+	    val textTime = new RecentTweet(recordLine.text, time, recordLine.userName)
 
 	    val newRecordsMap =
 	    	recordLine.topics

--- a/tile-examples/twitter-topics/twitter-topics-utilities/src/main/scala/com/oculusinfo/twitter/tilegen/TwitterTopicRecordParser.scala
+++ b/tile-examples/twitter-topics/twitter-topics-utilities/src/main/scala/com/oculusinfo/twitter/tilegen/TwitterTopicRecordParser.scala
@@ -105,11 +105,11 @@ class TwitterTopicRecordParser (endTimeSecs: Long) {
     Seq[((Double, Double), Map[String, TwitterDemoTopicRecord])] = {
     val recordLine = parseLine(line)
     val time = (recordLine.createdAt.getTime()*0.001).toLong	// convert from msec to sec
-    
+
     if ((endTimeSecs - time > 0L) && (endTimeSecs - time <= 2678400L)) {
     	// tweet time is valid time interva (i.e., within 1 month prior to endTime)    
-	    val textTime = new RecentTweet(recordLine.text, time, "", "")
-	
+	    val textTime = new RecentTweet(recordLine.text, time, recordLine.userName, "")
+
 	    val newRecordsMap =
 	    	recordLine.topics
 	    	          .zip(recordLine.topicsEng)		// Combine raw topic and translation

--- a/tile-examples/twitter-topics/twitter-topics-utilities/src/main/scala/com/oculusinfo/twitter/tilegen/TwitterTopicRecordParser.scala
+++ b/tile-examples/twitter-topics/twitter-topics-utilities/src/main/scala/com/oculusinfo/twitter/tilegen/TwitterTopicRecordParser.scala
@@ -38,7 +38,7 @@ import scala.util.parsing.json.JSON
 
 import com.oculusinfo.factory.util.Pair
 
-import com.oculusinfo.twitter.binning.TwitterDemoTopicRecord
+import com.oculusinfo.twitter.binning.{RecentTweet, TwitterDemoTopicRecord}
 
 private[tilegen]
 class TwitterTopicRecordLine (val createdAt: Date,
@@ -108,14 +108,14 @@ class TwitterTopicRecordParser (endTimeSecs: Long) {
     
     if ((endTimeSecs - time > 0L) && (endTimeSecs - time <= 2678400L)) {
     	// tweet time is valid time interva (i.e., within 1 month prior to endTime)    
-	    val textTime = new Pair[String, JavaLong](recordLine.text, time)
+	    val textTime = new RecentTweet(recordLine.text, time, "", "")
 	
 	    val newRecordsMap =
 	    	recordLine.topics
 	    	          .zip(recordLine.topicsEng)		// Combine raw topic and translation
 	                  .map{case (raw: String, english: String) => {
 	                    	 							// Change topic/translation pair to a topic record
-	    	val textTimeList = List[Pair[String, JavaLong]](textTime).asJava
+	    	val textTimeList = List[RecentTweet](textTime).asJava
 	    	(raw -> new TwitterDemoTopicRecord(raw, english, textTimeList, endTimeSecs))
 	    }}.toMap
 	

--- a/tile-examples/twitter-topics/twitter-topics-utilities/src/test/java/com/oculusinfo/twitter/binning/TwitterTopicTests.java
+++ b/tile-examples/twitter-topics/twitter-topics-utilities/src/test/java/com/oculusinfo/twitter/binning/TwitterTopicTests.java
@@ -47,7 +47,7 @@ public class TwitterTopicTests {
 													Arrays.asList(0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 																  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 																  0, 0, 0, 0),
-													Arrays.asList(new RecentTweet("", _endTimeSecs, "")),
+													Arrays.asList(new RecentTweet("", _endTimeSecs, "", "")),
 													_endTimeSecs);
 	
 	//---- Create a topic with no counts and an end time.
@@ -63,7 +63,7 @@ public class TwitterTopicTests {
 													Arrays.asList(0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 																  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 																  0, 0, 0, 0),
-													Arrays.asList(new RecentTweet("", _endTimeSecs, "")),
+													Arrays.asList(new RecentTweet("", _endTimeSecs, "", "")),
 													_endTimeSecs);
 			
 		Assert.assertEquals(_sampleRecord, a);
@@ -73,7 +73,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testAddTweetBeforeBeginning() {	
 		
-		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (2678400L+1), ""); // 1 month + 1 sec from end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (2678400L+1), "", ""); // 1 month + 1 sec from end time
 		
 		TwitterDemoTopicRecord a = TwitterDemoTopicRecord.addTweetToRecord(_sampleRecord, tweet1);
 		Assert.assertEquals(_sampleRecord, a);
@@ -83,7 +83,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testAddTweetAfterEnd() {	
 		
-		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs + 1L, ""); // 1 sec after end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs + 1L, "", ""); // 1 sec after end time
 
 		
 		TwitterDemoTopicRecord a = TwitterDemoTopicRecord.addTweetToRecord(_sampleRecord, tweet1);
@@ -94,7 +94,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testAddTweetMonthly() {	
 		
-		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (2678400L-1), ""); // 1 month - 1 sec from end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (2678400L-1), "", ""); // 1 month - 1 sec from end time
 		
 		TwitterDemoTopicRecord a = TwitterDemoTopicRecord.addTweetToRecord(_sampleRecord, tweet1);
 		Assert.assertEquals(a.getCountMonthly(), _sampleRecord.getCountMonthly()+1);
@@ -111,7 +111,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testAddTweetQuarterDaily() {	
 		
-		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (604800L-1), ""); // 7 days - 1 sec from end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (604800L-1), "", ""); // 7 days - 1 sec from end time
 	
 		TwitterDemoTopicRecord a = TwitterDemoTopicRecord.addTweetToRecord(_sampleRecord, tweet1);
 		Assert.assertEquals(a.getCountMonthly(), _sampleRecord.getCountMonthly()+1);
@@ -134,7 +134,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testAddTweetHourly() {	
 		
-		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, ""); // 1 sec prior to end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, "", ""); // 1 sec prior to end time
 	
 		TwitterDemoTopicRecord a = TwitterDemoTopicRecord.addTweetToRecord(_sampleRecord, tweet1);
 		Assert.assertEquals(a.getCountMonthly(), _sampleRecord.getCountMonthly()+1);
@@ -163,7 +163,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testConstructRecordBeforeBeginning() {	
 		
-		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (2678400L+1), ""); // 1 month + 1 sec from end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (2678400L+1), "", ""); // 1 month + 1 sec from end time
 		
 		TwitterDemoTopicRecord a = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopic, Arrays.asList(tweet1), _endTimeSecs);
 		Assert.assertEquals(a.getCountMonthly(), 0);
@@ -176,7 +176,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testConstructRecordAfterEnd() {	
 		
-		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs + 1L, ""); // 1 sec after end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs + 1L, "", ""); // 1 sec after end time
 
 		TwitterDemoTopicRecord a = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopic, Arrays.asList(tweet1), _endTimeSecs);
 		Assert.assertEquals(a.getCountMonthly(), 0);
@@ -189,7 +189,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testConstructRecordMonthly() {	
 		
-		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (2678400L-1), ""); // 1 month - 1 sec from end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (2678400L-1), "", ""); // 1 month - 1 sec from end time
 		
 		TwitterDemoTopicRecord a = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopic, Arrays.asList(tweet1), _endTimeSecs);
 		Assert.assertEquals(a.getCountMonthly(), _sampleRecord.getCountMonthly()+1);
@@ -206,7 +206,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testConstructRecordQuarterDaily() {	
 		
-		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (604800L-1), ""); // 7 days - 1 sec from end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (604800L-1), "", ""); // 7 days - 1 sec from end time
 	
 		TwitterDemoTopicRecord a = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopic, Arrays.asList(tweet1), _endTimeSecs);
 		Assert.assertEquals(a.getCountMonthly(), _sampleRecord.getCountMonthly()+1);
@@ -229,7 +229,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testConstructRecordHourly() {	
 		
-		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, ""); // 1 sec prior to end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, "", ""); // 1 sec prior to end time
 	
 		TwitterDemoTopicRecord a = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopic, Arrays.asList(tweet1), _endTimeSecs);
 		Assert.assertEquals(a.getCountMonthly(), _sampleRecord.getCountMonthly()+1);
@@ -266,7 +266,7 @@ public class TwitterTopicTests {
 								Arrays.asList(1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 										0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 										0, 0, 0, 0),
-								Arrays.asList(new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, "barry")),	// 1 sec prior to end time
+								Arrays.asList(new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, "barry", "")),	// 1 sec prior to end time
 								_endTimeSecs);
 
 		TwitterDemoTopicRecord b = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopicEnglish, 1, 
@@ -279,7 +279,7 @@ public class TwitterTopicTests {
 								Arrays.asList(0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
 										0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 										0, 0, 0, 0),
-								Arrays.asList(new RecentTweet("Nos todos amamos o futebol", _endTimeSecs - 3601L, "jorge")),	// 1 hr + 1 sec prior to end time
+								Arrays.asList(new RecentTweet("Nos todos amamos o futebol", _endTimeSecs - 3601L, "jorge", "")),	// 1 hr + 1 sec prior to end time
 								_endTimeSecs);
 
 		TwitterDemoTopicRecord c = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopicEnglish, 2, 
@@ -292,8 +292,8 @@ public class TwitterTopicTests {
 								Arrays.asList(1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
 										0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 										0, 0, 0, 0),
-								Arrays.asList(new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, "barry"),
-											  new RecentTweet("Nos todos amamos o futebol", _endTimeSecs - 3601L, "jorge")),
+								Arrays.asList(new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, "barry", ""),
+											  new RecentTweet("Nos todos amamos o futebol", _endTimeSecs - 3601L, "jorge", "")),
 								_endTimeSecs);		
 
 		Assert.assertEquals(c, TwitterDemoTopicRecord.addRecords(a, b));
@@ -312,7 +312,7 @@ public class TwitterTopicTests {
 													Arrays.asList(1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0),
-													Arrays.asList(new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, "")),	// 1 sec prior to end time
+													Arrays.asList(new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, "", "")),	// 1 sec prior to end time
 													_endTimeSecs);
 		
 		TwitterDemoTopicRecord b = new TwitterDemoTopicRecord("hoquei", "hockey", 1, 
@@ -325,7 +325,7 @@ public class TwitterTopicTests {
 													Arrays.asList(0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0),
-													Arrays.asList(new RecentTweet("Todos nos gostamos de hoquei", _endTimeSecs - 3601L, "")),	// 1 hr + 1 sec prior to end time
+													Arrays.asList(new RecentTweet("Todos nos gostamos de hoquei", _endTimeSecs - 3601L, "", "")),	// 1 hr + 1 sec prior to end time
 													_endTimeSecs);
 		
         TwitterDemoTopicRecord.addRecords(a, b);
@@ -345,9 +345,9 @@ public class TwitterTopicTests {
 													Arrays.asList(1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0),
-													Arrays.asList(new RecentTweet("blah1", _endTimeSecs - 1000L, ""),
-																new RecentTweet("blah2", _endTimeSecs - 2000L, ""),
-																new RecentTweet("blah3", _endTimeSecs - 3000L, "")),
+													Arrays.asList(new RecentTweet("blah1", _endTimeSecs - 1000L, "", ""),
+																new RecentTweet("blah2", _endTimeSecs - 2000L, "", ""),
+																new RecentTweet("blah3", _endTimeSecs - 3000L, "", "")),
 													_endTimeSecs);
 		
 		TwitterDemoTopicRecord b = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopicEnglish, 17, 
@@ -360,9 +360,9 @@ public class TwitterTopicTests {
 													Arrays.asList(0, 0, 0, 0, 0, 0, 1, 0, 0, 0,
 															0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0),
-													Arrays.asList(new RecentTweet("blah3", _endTimeSecs - 1500L, ""),
-																new RecentTweet("blah4", _endTimeSecs - 2500L, ""),
-																new RecentTweet("blah5", _endTimeSecs - 3500L, "")),
+													Arrays.asList(new RecentTweet("blah3", _endTimeSecs - 1500L, "", ""),
+																new RecentTweet("blah4", _endTimeSecs - 2500L, "", ""),
+																new RecentTweet("blah5", _endTimeSecs - 3500L, "", "")),
 													_endTimeSecs);
 
 		TwitterDemoTopicRecord c = new TwitterDemoTopicRecord(null, null, 15, 
@@ -395,9 +395,9 @@ public class TwitterTopicTests {
 													Arrays.asList(1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0),
-													Arrays.asList(new RecentTweet("blah1", _endTimeSecs - 1000L, ""),
-																new RecentTweet("blah2", _endTimeSecs - 2000L, ""),
-																new RecentTweet("blah3", _endTimeSecs - 3000L, "")),
+													Arrays.asList(new RecentTweet("blah1", _endTimeSecs - 1000L, "", ""),
+																new RecentTweet("blah2", _endTimeSecs - 2000L, "", ""),
+																new RecentTweet("blah3", _endTimeSecs - 3000L, "", "")),
 													_endTimeSecs);
 		
 		TwitterDemoTopicRecord b = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopicEnglish, 17, 
@@ -410,9 +410,9 @@ public class TwitterTopicTests {
 													Arrays.asList(0, 0, 0, 0, 0, 0, 1, 0, 0, 0,
 															0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0),
-													Arrays.asList(new RecentTweet("blah3", _endTimeSecs - 1500L, ""),
-																new RecentTweet("blah4", _endTimeSecs - 2500L, ""),
-																new RecentTweet("blah5", _endTimeSecs - 3500L, "")),
+													Arrays.asList(new RecentTweet("blah3", _endTimeSecs - 1500L, "", ""),
+																new RecentTweet("blah4", _endTimeSecs - 2500L, "", ""),
+																new RecentTweet("blah5", _endTimeSecs - 3500L, "", "")),
 													_endTimeSecs);
 
 		TwitterDemoTopicRecord c = new TwitterDemoTopicRecord(null, null, 17, 
@@ -443,8 +443,8 @@ public class TwitterTopicTests {
 													Arrays.asList(1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0),
-													Arrays.asList(new RecentTweet("abcdef", _endTimeSecs - 1000L, "bob"),
-															new RecentTweet("abc\"\"\\\"\\\\\"\\\\\\\"def", _endTimeSecs - 2000L, "alice")),
+													Arrays.asList(new RecentTweet("abcdef", _endTimeSecs - 1000L, "bob", "neg"),
+															new RecentTweet("abc\"\"\\\"\\\\\"\\\\\\\"def", _endTimeSecs - 2000L, "alice", "pos")),
 													_endTimeSecs);    	
 
         String as = a.toString();

--- a/tile-examples/twitter-topics/twitter-topics-utilities/src/test/java/com/oculusinfo/twitter/binning/TwitterTopicTests.java
+++ b/tile-examples/twitter-topics/twitter-topics-utilities/src/test/java/com/oculusinfo/twitter/binning/TwitterTopicTests.java
@@ -443,8 +443,8 @@ public class TwitterTopicTests {
 													Arrays.asList(1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0),
-													Arrays.asList(new RecentTweet("abcdef", _endTimeSecs - 1000L, "", ""),
-															new RecentTweet("abc\"\"\\\"\\\\\"\\\\\\\"def", _endTimeSecs - 2000L, "", "")),
+													Arrays.asList(new RecentTweet("abcdef", _endTimeSecs - 1000L, "bob", "neg"),
+															new RecentTweet("abc\"\"\\\"\\\\\"\\\\\\\"def", _endTimeSecs - 2000L, "alice", "pos")),
 													_endTimeSecs);    	
 
         String as = a.toString();

--- a/tile-examples/twitter-topics/twitter-topics-utilities/src/test/java/com/oculusinfo/twitter/binning/TwitterTopicTests.java
+++ b/tile-examples/twitter-topics/twitter-topics-utilities/src/test/java/com/oculusinfo/twitter/binning/TwitterTopicTests.java
@@ -24,13 +24,11 @@
  */
 package com.oculusinfo.twitter.binning;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-
 import org.junit.Assert;
 import org.junit.Test;
 
-import com.oculusinfo.factory.util.Pair;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 public class TwitterTopicTests {
 
@@ -268,7 +266,7 @@ public class TwitterTopicTests {
 								Arrays.asList(1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 										0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 										0, 0, 0, 0),
-								Arrays.asList(new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, "", "")),	// 1 sec prior to end time
+								Arrays.asList(new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, "barry", "")),	// 1 sec prior to end time
 								_endTimeSecs);
 
 		TwitterDemoTopicRecord b = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopicEnglish, 1, 
@@ -281,7 +279,7 @@ public class TwitterTopicTests {
 								Arrays.asList(0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
 										0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 										0, 0, 0, 0),
-								Arrays.asList(new RecentTweet("Nos todos amamos o futebol", _endTimeSecs - 3601L, "", "")),	// 1 hr + 1 sec prior to end time
+								Arrays.asList(new RecentTweet("Nos todos amamos o futebol", _endTimeSecs - 3601L, "jorge", "")),	// 1 hr + 1 sec prior to end time
 								_endTimeSecs);
 
 		TwitterDemoTopicRecord c = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopicEnglish, 2, 
@@ -294,8 +292,8 @@ public class TwitterTopicTests {
 								Arrays.asList(1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
 										0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 										0, 0, 0, 0),
-								Arrays.asList(new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, "", ""),
-											  new RecentTweet("Nos todos amamos o futebol", _endTimeSecs - 3601L, "", "")),
+								Arrays.asList(new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, "barry", ""),
+											  new RecentTweet("Nos todos amamos o futebol", _endTimeSecs - 3601L, "jorge", "")),
 								_endTimeSecs);		
 
 		Assert.assertEquals(c, TwitterDemoTopicRecord.addRecords(a, b));
@@ -387,7 +385,7 @@ public class TwitterTopicTests {
 	//---- Max of two records
     @Test
     public void testMax() {
-		TwitterDemoTopicRecord a = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopicEnglish, 15, 
+		TwitterDemoTopicRecord a = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopicEnglish, 15,
 													Arrays.asList(1, 0, 0, 0, 0, 0, 5, 0, 0, 0,
 																0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 																0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 9),
@@ -451,15 +449,15 @@ public class TwitterTopicTests {
 
         String as = a.toString();
         TwitterDemoTopicRecord b = TwitterDemoTopicRecord.fromString(as);
-//        Assert.assertEquals(a, b);
-        Assert.assertEquals(a.getTopic(), b.getTopic());
-        Assert.assertEquals(a.getTopicEnglish(), b.getTopicEnglish());
-        Assert.assertEquals(a.getCountDaily(), b.getCountDaily());
-        Assert.assertEquals(a.getCountPer6hrs(), b.getCountPer6hrs());
-        Assert.assertEquals(a.getCountPerHour(), b.getCountPerHour());
-        Assert.assertEquals(a.getRecentTweets(), b.getRecentTweets());
-        Assert.assertTrue(a.getCountMonthly() == b.getCountMonthly());
-        Assert.assertTrue(a.getEndTime() == b.getEndTime());
+        Assert.assertEquals(a, b);
+//        Assert.assertEquals(a.getTopic(), b.getTopic());
+//        Assert.assertEquals(a.getTopicEnglish(), b.getTopicEnglish());
+//        Assert.assertEquals(a.getCountDaily(), b.getCountDaily());
+//        Assert.assertEquals(a.getCountPer6hrs(), b.getCountPer6hrs());
+//        Assert.assertEquals(a.getCountPerHour(), b.getCountPerHour());
+//        Assert.assertEquals(a.getRecentTweets(), b.getRecentTweets());
+//        Assert.assertTrue(a.getCountMonthly() == b.getCountMonthly());
+//        Assert.assertTrue(a.getEndTime() == b.getEndTime());
     }
 	
 }

--- a/tile-examples/twitter-topics/twitter-topics-utilities/src/test/java/com/oculusinfo/twitter/binning/TwitterTopicTests.java
+++ b/tile-examples/twitter-topics/twitter-topics-utilities/src/test/java/com/oculusinfo/twitter/binning/TwitterTopicTests.java
@@ -47,7 +47,7 @@ public class TwitterTopicTests {
 													Arrays.asList(0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 																  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 																  0, 0, 0, 0),
-													Arrays.asList(new RecentTweet("", _endTimeSecs, "", "")),
+													Arrays.asList(new RecentTweet("", _endTimeSecs, "")),
 													_endTimeSecs);
 	
 	//---- Create a topic with no counts and an end time.
@@ -63,7 +63,7 @@ public class TwitterTopicTests {
 													Arrays.asList(0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 																  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 																  0, 0, 0, 0),
-													Arrays.asList(new RecentTweet("", _endTimeSecs, "", "")),
+													Arrays.asList(new RecentTweet("", _endTimeSecs, "")),
 													_endTimeSecs);
 			
 		Assert.assertEquals(_sampleRecord, a);
@@ -73,7 +73,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testAddTweetBeforeBeginning() {	
 		
-		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (2678400L+1), "", ""); // 1 month + 1 sec from end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (2678400L+1), ""); // 1 month + 1 sec from end time
 		
 		TwitterDemoTopicRecord a = TwitterDemoTopicRecord.addTweetToRecord(_sampleRecord, tweet1);
 		Assert.assertEquals(_sampleRecord, a);
@@ -83,7 +83,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testAddTweetAfterEnd() {	
 		
-		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs + 1L, "", ""); // 1 sec after end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs + 1L, ""); // 1 sec after end time
 
 		
 		TwitterDemoTopicRecord a = TwitterDemoTopicRecord.addTweetToRecord(_sampleRecord, tweet1);
@@ -94,7 +94,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testAddTweetMonthly() {	
 		
-		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (2678400L-1), "", ""); // 1 month - 1 sec from end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (2678400L-1), ""); // 1 month - 1 sec from end time
 		
 		TwitterDemoTopicRecord a = TwitterDemoTopicRecord.addTweetToRecord(_sampleRecord, tweet1);
 		Assert.assertEquals(a.getCountMonthly(), _sampleRecord.getCountMonthly()+1);
@@ -111,7 +111,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testAddTweetQuarterDaily() {	
 		
-		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (604800L-1), "", ""); // 7 days - 1 sec from end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (604800L-1), ""); // 7 days - 1 sec from end time
 	
 		TwitterDemoTopicRecord a = TwitterDemoTopicRecord.addTweetToRecord(_sampleRecord, tweet1);
 		Assert.assertEquals(a.getCountMonthly(), _sampleRecord.getCountMonthly()+1);
@@ -134,7 +134,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testAddTweetHourly() {	
 		
-		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, "", ""); // 1 sec prior to end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, ""); // 1 sec prior to end time
 	
 		TwitterDemoTopicRecord a = TwitterDemoTopicRecord.addTweetToRecord(_sampleRecord, tweet1);
 		Assert.assertEquals(a.getCountMonthly(), _sampleRecord.getCountMonthly()+1);
@@ -163,7 +163,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testConstructRecordBeforeBeginning() {	
 		
-		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (2678400L+1), "", ""); // 1 month + 1 sec from end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (2678400L+1), ""); // 1 month + 1 sec from end time
 		
 		TwitterDemoTopicRecord a = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopic, Arrays.asList(tweet1), _endTimeSecs);
 		Assert.assertEquals(a.getCountMonthly(), 0);
@@ -176,7 +176,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testConstructRecordAfterEnd() {	
 		
-		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs + 1L, "", ""); // 1 sec after end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs + 1L, ""); // 1 sec after end time
 
 		TwitterDemoTopicRecord a = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopic, Arrays.asList(tweet1), _endTimeSecs);
 		Assert.assertEquals(a.getCountMonthly(), 0);
@@ -189,7 +189,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testConstructRecordMonthly() {	
 		
-		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (2678400L-1), "", ""); // 1 month - 1 sec from end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (2678400L-1), ""); // 1 month - 1 sec from end time
 		
 		TwitterDemoTopicRecord a = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopic, Arrays.asList(tweet1), _endTimeSecs);
 		Assert.assertEquals(a.getCountMonthly(), _sampleRecord.getCountMonthly()+1);
@@ -206,7 +206,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testConstructRecordQuarterDaily() {	
 		
-		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (604800L-1), "", ""); // 7 days - 1 sec from end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (604800L-1), ""); // 7 days - 1 sec from end time
 	
 		TwitterDemoTopicRecord a = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopic, Arrays.asList(tweet1), _endTimeSecs);
 		Assert.assertEquals(a.getCountMonthly(), _sampleRecord.getCountMonthly()+1);
@@ -229,7 +229,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testConstructRecordHourly() {	
 		
-		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, "", ""); // 1 sec prior to end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, ""); // 1 sec prior to end time
 	
 		TwitterDemoTopicRecord a = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopic, Arrays.asList(tweet1), _endTimeSecs);
 		Assert.assertEquals(a.getCountMonthly(), _sampleRecord.getCountMonthly()+1);
@@ -266,7 +266,7 @@ public class TwitterTopicTests {
 								Arrays.asList(1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 										0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 										0, 0, 0, 0),
-								Arrays.asList(new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, "barry", "")),	// 1 sec prior to end time
+								Arrays.asList(new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, "barry")),	// 1 sec prior to end time
 								_endTimeSecs);
 
 		TwitterDemoTopicRecord b = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopicEnglish, 1, 
@@ -279,7 +279,7 @@ public class TwitterTopicTests {
 								Arrays.asList(0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
 										0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 										0, 0, 0, 0),
-								Arrays.asList(new RecentTweet("Nos todos amamos o futebol", _endTimeSecs - 3601L, "jorge", "")),	// 1 hr + 1 sec prior to end time
+								Arrays.asList(new RecentTweet("Nos todos amamos o futebol", _endTimeSecs - 3601L, "jorge")),	// 1 hr + 1 sec prior to end time
 								_endTimeSecs);
 
 		TwitterDemoTopicRecord c = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopicEnglish, 2, 
@@ -292,8 +292,8 @@ public class TwitterTopicTests {
 								Arrays.asList(1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
 										0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 										0, 0, 0, 0),
-								Arrays.asList(new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, "barry", ""),
-											  new RecentTweet("Nos todos amamos o futebol", _endTimeSecs - 3601L, "jorge", "")),
+								Arrays.asList(new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, "barry"),
+											  new RecentTweet("Nos todos amamos o futebol", _endTimeSecs - 3601L, "jorge")),
 								_endTimeSecs);		
 
 		Assert.assertEquals(c, TwitterDemoTopicRecord.addRecords(a, b));
@@ -312,7 +312,7 @@ public class TwitterTopicTests {
 													Arrays.asList(1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0),
-													Arrays.asList(new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, "", "")),	// 1 sec prior to end time
+													Arrays.asList(new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, "")),	// 1 sec prior to end time
 													_endTimeSecs);
 		
 		TwitterDemoTopicRecord b = new TwitterDemoTopicRecord("hoquei", "hockey", 1, 
@@ -325,7 +325,7 @@ public class TwitterTopicTests {
 													Arrays.asList(0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0),
-													Arrays.asList(new RecentTweet("Todos nos gostamos de hoquei", _endTimeSecs - 3601L, "", "")),	// 1 hr + 1 sec prior to end time
+													Arrays.asList(new RecentTweet("Todos nos gostamos de hoquei", _endTimeSecs - 3601L, "")),	// 1 hr + 1 sec prior to end time
 													_endTimeSecs);
 		
         TwitterDemoTopicRecord.addRecords(a, b);
@@ -345,9 +345,9 @@ public class TwitterTopicTests {
 													Arrays.asList(1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0),
-													Arrays.asList(new RecentTweet("blah1", _endTimeSecs - 1000L, "", ""),
-																new RecentTweet("blah2", _endTimeSecs - 2000L, "", ""),
-																new RecentTweet("blah3", _endTimeSecs - 3000L, "", "")),
+													Arrays.asList(new RecentTweet("blah1", _endTimeSecs - 1000L, ""),
+																new RecentTweet("blah2", _endTimeSecs - 2000L, ""),
+																new RecentTweet("blah3", _endTimeSecs - 3000L, "")),
 													_endTimeSecs);
 		
 		TwitterDemoTopicRecord b = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopicEnglish, 17, 
@@ -360,9 +360,9 @@ public class TwitterTopicTests {
 													Arrays.asList(0, 0, 0, 0, 0, 0, 1, 0, 0, 0,
 															0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0),
-													Arrays.asList(new RecentTweet("blah3", _endTimeSecs - 1500L, "", ""),
-																new RecentTweet("blah4", _endTimeSecs - 2500L, "", ""),
-																new RecentTweet("blah5", _endTimeSecs - 3500L, "", "")),
+													Arrays.asList(new RecentTweet("blah3", _endTimeSecs - 1500L, ""),
+																new RecentTweet("blah4", _endTimeSecs - 2500L, ""),
+																new RecentTweet("blah5", _endTimeSecs - 3500L, "")),
 													_endTimeSecs);
 
 		TwitterDemoTopicRecord c = new TwitterDemoTopicRecord(null, null, 15, 
@@ -395,9 +395,9 @@ public class TwitterTopicTests {
 													Arrays.asList(1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0),
-													Arrays.asList(new RecentTweet("blah1", _endTimeSecs - 1000L, "", ""),
-																new RecentTweet("blah2", _endTimeSecs - 2000L, "", ""),
-																new RecentTweet("blah3", _endTimeSecs - 3000L, "", "")),
+													Arrays.asList(new RecentTweet("blah1", _endTimeSecs - 1000L, ""),
+																new RecentTweet("blah2", _endTimeSecs - 2000L, ""),
+																new RecentTweet("blah3", _endTimeSecs - 3000L, "")),
 													_endTimeSecs);
 		
 		TwitterDemoTopicRecord b = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopicEnglish, 17, 
@@ -410,9 +410,9 @@ public class TwitterTopicTests {
 													Arrays.asList(0, 0, 0, 0, 0, 0, 1, 0, 0, 0,
 															0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0),
-													Arrays.asList(new RecentTweet("blah3", _endTimeSecs - 1500L, "", ""),
-																new RecentTweet("blah4", _endTimeSecs - 2500L, "", ""),
-																new RecentTweet("blah5", _endTimeSecs - 3500L, "", "")),
+													Arrays.asList(new RecentTweet("blah3", _endTimeSecs - 1500L, ""),
+																new RecentTweet("blah4", _endTimeSecs - 2500L, ""),
+																new RecentTweet("blah5", _endTimeSecs - 3500L, "")),
 													_endTimeSecs);
 
 		TwitterDemoTopicRecord c = new TwitterDemoTopicRecord(null, null, 17, 
@@ -443,8 +443,8 @@ public class TwitterTopicTests {
 													Arrays.asList(1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0),
-													Arrays.asList(new RecentTweet("abcdef", _endTimeSecs - 1000L, "bob", "neg"),
-															new RecentTweet("abc\"\"\\\"\\\\\"\\\\\\\"def", _endTimeSecs - 2000L, "alice", "pos")),
+													Arrays.asList(new RecentTweet("abcdef", _endTimeSecs - 1000L, "bob"),
+															new RecentTweet("abc\"\"\\\"\\\\\"\\\\\\\"def", _endTimeSecs - 2000L, "alice")),
 													_endTimeSecs);    	
 
         String as = a.toString();

--- a/tile-examples/twitter-topics/twitter-topics-utilities/src/test/java/com/oculusinfo/twitter/binning/TwitterTopicTests.java
+++ b/tile-examples/twitter-topics/twitter-topics-utilities/src/test/java/com/oculusinfo/twitter/binning/TwitterTopicTests.java
@@ -49,7 +49,7 @@ public class TwitterTopicTests {
 													Arrays.asList(0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 																  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 																  0, 0, 0, 0),
-													Arrays.asList(new Pair<String, Long>("", _endTimeSecs)),
+													Arrays.asList(new RecentTweet("", _endTimeSecs, "", "")),
 													_endTimeSecs);
 	
 	//---- Create a topic with no counts and an end time.
@@ -65,7 +65,7 @@ public class TwitterTopicTests {
 													Arrays.asList(0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 																  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 																  0, 0, 0, 0),
-													Arrays.asList(new Pair<String, Long>("", _endTimeSecs)),
+													Arrays.asList(new RecentTweet("", _endTimeSecs, "", "")),
 													_endTimeSecs);
 			
 		Assert.assertEquals(_sampleRecord, a);
@@ -75,7 +75,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testAddTweetBeforeBeginning() {	
 		
-		Pair<String, Long> tweet1 = new Pair<String, Long>("Eu amo o futebol", _endTimeSecs - (2678400L+1)); // 1 month + 1 sec from end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (2678400L+1), "", ""); // 1 month + 1 sec from end time
 		
 		TwitterDemoTopicRecord a = TwitterDemoTopicRecord.addTweetToRecord(_sampleRecord, tweet1);
 		Assert.assertEquals(_sampleRecord, a);
@@ -85,7 +85,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testAddTweetAfterEnd() {	
 		
-		Pair<String, Long> tweet1 = new Pair<String, Long>("Eu amo o futebol", _endTimeSecs + 1L); // 1 sec after end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs + 1L, "", ""); // 1 sec after end time
 
 		
 		TwitterDemoTopicRecord a = TwitterDemoTopicRecord.addTweetToRecord(_sampleRecord, tweet1);
@@ -96,7 +96,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testAddTweetMonthly() {	
 		
-		Pair<String, Long> tweet1 = new Pair<String, Long>("Eu amo o futebol", _endTimeSecs - (2678400L-1)); // 1 month - 1 sec from end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (2678400L-1), "", ""); // 1 month - 1 sec from end time
 		
 		TwitterDemoTopicRecord a = TwitterDemoTopicRecord.addTweetToRecord(_sampleRecord, tweet1);
 		Assert.assertEquals(a.getCountMonthly(), _sampleRecord.getCountMonthly()+1);
@@ -113,7 +113,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testAddTweetQuarterDaily() {	
 		
-		Pair<String, Long> tweet1 = new Pair<String, Long>("Eu amo o futebol", _endTimeSecs - (604800L-1)); // 7 days - 1 sec from end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (604800L-1), "", ""); // 7 days - 1 sec from end time
 	
 		TwitterDemoTopicRecord a = TwitterDemoTopicRecord.addTweetToRecord(_sampleRecord, tweet1);
 		Assert.assertEquals(a.getCountMonthly(), _sampleRecord.getCountMonthly()+1);
@@ -136,7 +136,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testAddTweetHourly() {	
 		
-		Pair<String, Long> tweet1 = new Pair<String, Long>("Eu amo o futebol", _endTimeSecs - 1L); // 1 sec prior to end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, "", ""); // 1 sec prior to end time
 	
 		TwitterDemoTopicRecord a = TwitterDemoTopicRecord.addTweetToRecord(_sampleRecord, tweet1);
 		Assert.assertEquals(a.getCountMonthly(), _sampleRecord.getCountMonthly()+1);
@@ -165,7 +165,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testConstructRecordBeforeBeginning() {	
 		
-		Pair<String, Long> tweet1 = new Pair<String, Long>("Eu amo o futebol", _endTimeSecs - (2678400L+1)); // 1 month + 1 sec from end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (2678400L+1), "", ""); // 1 month + 1 sec from end time
 		
 		TwitterDemoTopicRecord a = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopic, Arrays.asList(tweet1), _endTimeSecs);
 		Assert.assertEquals(a.getCountMonthly(), 0);
@@ -178,7 +178,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testConstructRecordAfterEnd() {	
 		
-		Pair<String, Long> tweet1 = new Pair<String, Long>("Eu amo o futebol", _endTimeSecs + 1L); // 1 sec after end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs + 1L, "", ""); // 1 sec after end time
 
 		TwitterDemoTopicRecord a = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopic, Arrays.asList(tweet1), _endTimeSecs);
 		Assert.assertEquals(a.getCountMonthly(), 0);
@@ -191,7 +191,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testConstructRecordMonthly() {	
 		
-		Pair<String, Long> tweet1 = new Pair<String, Long>("Eu amo o futebol", _endTimeSecs - (2678400L-1)); // 1 month - 1 sec from end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (2678400L-1), "", ""); // 1 month - 1 sec from end time
 		
 		TwitterDemoTopicRecord a = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopic, Arrays.asList(tweet1), _endTimeSecs);
 		Assert.assertEquals(a.getCountMonthly(), _sampleRecord.getCountMonthly()+1);
@@ -208,7 +208,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testConstructRecordQuarterDaily() {	
 		
-		Pair<String, Long> tweet1 = new Pair<String, Long>("Eu amo o futebol", _endTimeSecs - (604800L-1)); // 7 days - 1 sec from end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - (604800L-1), "", ""); // 7 days - 1 sec from end time
 	
 		TwitterDemoTopicRecord a = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopic, Arrays.asList(tweet1), _endTimeSecs);
 		Assert.assertEquals(a.getCountMonthly(), _sampleRecord.getCountMonthly()+1);
@@ -231,7 +231,7 @@ public class TwitterTopicTests {
 	@Test
 	public void testConstructRecordHourly() {	
 		
-		Pair<String, Long> tweet1 = new Pair<String, Long>("Eu amo o futebol", _endTimeSecs - 1L); // 1 sec prior to end time
+		RecentTweet tweet1 = new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, "", ""); // 1 sec prior to end time
 	
 		TwitterDemoTopicRecord a = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopic, Arrays.asList(tweet1), _endTimeSecs);
 		Assert.assertEquals(a.getCountMonthly(), _sampleRecord.getCountMonthly()+1);
@@ -268,7 +268,7 @@ public class TwitterTopicTests {
 								Arrays.asList(1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 										0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 										0, 0, 0, 0),
-								Arrays.asList(new Pair<String, Long>("Eu amo o futebol", _endTimeSecs - 1L)),	// 1 sec prior to end time
+								Arrays.asList(new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, "", "")),	// 1 sec prior to end time
 								_endTimeSecs);
 
 		TwitterDemoTopicRecord b = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopicEnglish, 1, 
@@ -281,7 +281,7 @@ public class TwitterTopicTests {
 								Arrays.asList(0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
 										0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 										0, 0, 0, 0),
-								Arrays.asList(new Pair<String, Long>("Nos todos amamos o futebol", _endTimeSecs - 3601L)),	// 1 hr + 1 sec prior to end time
+								Arrays.asList(new RecentTweet("Nos todos amamos o futebol", _endTimeSecs - 3601L, "", "")),	// 1 hr + 1 sec prior to end time
 								_endTimeSecs);
 
 		TwitterDemoTopicRecord c = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopicEnglish, 2, 
@@ -294,8 +294,8 @@ public class TwitterTopicTests {
 								Arrays.asList(1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
 										0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 										0, 0, 0, 0),
-								Arrays.asList(new Pair<String, Long>("Eu amo o futebol", _endTimeSecs - 1L),
-											  new Pair<String, Long>("Nos todos amamos o futebol", _endTimeSecs - 3601L)),
+								Arrays.asList(new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, "", ""),
+											  new RecentTweet("Nos todos amamos o futebol", _endTimeSecs - 3601L, "", "")),
 								_endTimeSecs);		
 
 		Assert.assertEquals(c, TwitterDemoTopicRecord.addRecords(a, b));
@@ -314,7 +314,7 @@ public class TwitterTopicTests {
 													Arrays.asList(1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0),
-													Arrays.asList(new Pair<String, Long>("Eu amo o futebol", _endTimeSecs - 1L)),	// 1 sec prior to end time
+													Arrays.asList(new RecentTweet("Eu amo o futebol", _endTimeSecs - 1L, "", "")),	// 1 sec prior to end time
 													_endTimeSecs);
 		
 		TwitterDemoTopicRecord b = new TwitterDemoTopicRecord("hoquei", "hockey", 1, 
@@ -327,7 +327,7 @@ public class TwitterTopicTests {
 													Arrays.asList(0, 1, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0),
-													Arrays.asList(new Pair<String, Long>("Todos nos gostamos de hoquei", _endTimeSecs - 3601L)),	// 1 hr + 1 sec prior to end time
+													Arrays.asList(new RecentTweet("Todos nos gostamos de hoquei", _endTimeSecs - 3601L, "", "")),	// 1 hr + 1 sec prior to end time
 													_endTimeSecs);
 		
         TwitterDemoTopicRecord.addRecords(a, b);
@@ -347,9 +347,9 @@ public class TwitterTopicTests {
 													Arrays.asList(1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0),
-													Arrays.asList(new Pair<String, Long>("blah1", _endTimeSecs - 1000L),
-																new Pair<String, Long>("blah2", _endTimeSecs - 2000L),
-																new Pair<String, Long>("blah3", _endTimeSecs - 3000L)),
+													Arrays.asList(new RecentTweet("blah1", _endTimeSecs - 1000L, "", ""),
+																new RecentTweet("blah2", _endTimeSecs - 2000L, "", ""),
+																new RecentTweet("blah3", _endTimeSecs - 3000L, "", "")),
 													_endTimeSecs);
 		
 		TwitterDemoTopicRecord b = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopicEnglish, 17, 
@@ -362,9 +362,9 @@ public class TwitterTopicTests {
 													Arrays.asList(0, 0, 0, 0, 0, 0, 1, 0, 0, 0,
 															0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0),
-													Arrays.asList(new Pair<String, Long>("blah3", _endTimeSecs - 1500L),
-																new Pair<String, Long>("blah4", _endTimeSecs - 2500L),
-																new Pair<String, Long>("blah5", _endTimeSecs - 3500L)),
+													Arrays.asList(new RecentTweet("blah3", _endTimeSecs - 1500L, "", ""),
+																new RecentTweet("blah4", _endTimeSecs - 2500L, "", ""),
+																new RecentTweet("blah5", _endTimeSecs - 3500L, "", "")),
 													_endTimeSecs);
 
 		TwitterDemoTopicRecord c = new TwitterDemoTopicRecord(null, null, 15, 
@@ -377,7 +377,7 @@ public class TwitterTopicTests {
 													Arrays.asList(0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0),
-													new ArrayList<Pair<String, Long>>(),
+													new ArrayList<RecentTweet>(),
 													_endTimeSecs);
 		
         Assert.assertEquals(c, TwitterDemoTopicRecord.minOfRecords(a, b));
@@ -397,9 +397,9 @@ public class TwitterTopicTests {
 													Arrays.asList(1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0),
-													Arrays.asList(new Pair<String, Long>("blah1", _endTimeSecs - 1000L),
-																new Pair<String, Long>("blah2", _endTimeSecs - 2000L),
-																new Pair<String, Long>("blah3", _endTimeSecs - 3000L)),
+													Arrays.asList(new RecentTweet("blah1", _endTimeSecs - 1000L, "", ""),
+																new RecentTweet("blah2", _endTimeSecs - 2000L, "", ""),
+																new RecentTweet("blah3", _endTimeSecs - 3000L, "", "")),
 													_endTimeSecs);
 		
 		TwitterDemoTopicRecord b = new TwitterDemoTopicRecord(_sampleTopic, _sampleTopicEnglish, 17, 
@@ -412,9 +412,9 @@ public class TwitterTopicTests {
 													Arrays.asList(0, 0, 0, 0, 0, 0, 1, 0, 0, 0,
 															0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0),
-													Arrays.asList(new Pair<String, Long>("blah3", _endTimeSecs - 1500L),
-																new Pair<String, Long>("blah4", _endTimeSecs - 2500L),
-																new Pair<String, Long>("blah5", _endTimeSecs - 3500L)),
+													Arrays.asList(new RecentTweet("blah3", _endTimeSecs - 1500L, "", ""),
+																new RecentTweet("blah4", _endTimeSecs - 2500L, "", ""),
+																new RecentTweet("blah5", _endTimeSecs - 3500L, "", "")),
 													_endTimeSecs);
 
 		TwitterDemoTopicRecord c = new TwitterDemoTopicRecord(null, null, 17, 
@@ -427,7 +427,7 @@ public class TwitterTopicTests {
 													Arrays.asList(1, 0, 0, 0, 0, 0, 1, 0, 0, 0,
 															0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0),
-													new ArrayList<Pair<String, Long>>(),
+													new ArrayList<RecentTweet>(),
 													_endTimeSecs);
         Assert.assertEquals(c, TwitterDemoTopicRecord.maxOfRecords(a, b));
     }  
@@ -445,21 +445,21 @@ public class TwitterTopicTests {
 													Arrays.asList(1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 															0, 0, 0, 0),
-													Arrays.asList(new Pair<String, Long>("abcdef", _endTimeSecs - 1000L),
-															new Pair<String, Long>("abc\"\"\\\"\\\\\"\\\\\\\"def", _endTimeSecs - 2000L)),
+													Arrays.asList(new RecentTweet("abcdef", _endTimeSecs - 1000L, "", ""),
+															new RecentTweet("abc\"\"\\\"\\\\\"\\\\\\\"def", _endTimeSecs - 2000L, "", "")),
 													_endTimeSecs);    	
 
         String as = a.toString();
         TwitterDemoTopicRecord b = TwitterDemoTopicRecord.fromString(as);
-        Assert.assertEquals(a, b);
-//        Assert.assertEquals(a.getTopic(), b.getTopic());
-//        Assert.assertEquals(a.getTopicEnglish(), b.getTopicEnglish());
-//        Assert.assertEquals(a.getCountDaily(), b.getCountDaily());
-//        Assert.assertEquals(a.getCountPer6hrs(), b.getCountPer6hrs());
-//        Assert.assertEquals(a.getCountPerHour(), b.getCountPerHour());
-//        Assert.assertEquals(a.getRecentTweets(), b.getRecentTweets());
-//        Assert.assertTrue(a.getCountMonthly() == b.getCountMonthly());
-//        Assert.assertTrue(a.getEndTime() == b.getEndTime());
+//        Assert.assertEquals(a, b);
+        Assert.assertEquals(a.getTopic(), b.getTopic());
+        Assert.assertEquals(a.getTopicEnglish(), b.getTopicEnglish());
+        Assert.assertEquals(a.getCountDaily(), b.getCountDaily());
+        Assert.assertEquals(a.getCountPer6hrs(), b.getCountPer6hrs());
+        Assert.assertEquals(a.getCountPerHour(), b.getCountPerHour());
+        Assert.assertEquals(a.getRecentTweets(), b.getRecentTweets());
+        Assert.assertTrue(a.getCountMonthly() == b.getCountMonthly());
+        Assert.assertTrue(a.getEndTime() == b.getEndTime());
     }
 	
 }


### PR DESCRIPTION
Adds fields for user name and sentiment to Twitter Topic recent tweets.  Sentiment isn't used in the current examples, but the twitter topc examples will be replaced with something simpler in the near future.  Also fixes a number of small errors encountered when building tiles during testing.