### PR TITLE
Make Avro serializers serializable even after they are used.

### DIFF
--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/GenericAvroArraySerializer.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/GenericAvroArraySerializer.java
@@ -45,7 +45,7 @@ abstract public class GenericAvroArraySerializer<T> extends GenericAvroSerialize
 		super(compressionCodec, new TypeDescriptor(List.class, elementTypeDescription));
 	}
 
-	private Schema _entrySchema;
+	transient private Schema _entrySchema;
 	
 	abstract protected String getEntrySchemaFile ();
 	abstract protected T getEntryValue (GenericRecord entry);
@@ -58,7 +58,7 @@ abstract public class GenericAvroArraySerializer<T> extends GenericAvroSerialize
 
 	protected Schema getEntrySchema () throws IOException {
 		if (_entrySchema == null) {
-				_entrySchema = createEntrySchema();
+			_entrySchema = createEntrySchema();
 		}
 		return _entrySchema;
 	}

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/GenericAvroSerializer.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/GenericAvroSerializer.java
@@ -36,6 +36,7 @@ import com.oculusinfo.binning.DenseTileData;
 import com.oculusinfo.binning.SparseTileData;
 import com.oculusinfo.binning.TileData.StorageType;
 import com.oculusinfo.factory.util.Pair;
+
 import org.apache.avro.Schema;
 import org.apache.avro.file.CodecFactory;
 import org.apache.avro.file.DataFileStream;
@@ -73,16 +74,16 @@ abstract public class GenericAvroSerializer<T> implements TileSerializer<T> {
 
 
 
-	private Map<StorageType, Schema> _tileSchema;
-	private Schema                   _recordSchema;
+	private transient ThreadLocal<Map<StorageType, Schema>> _tileSchema;
+	private transient Schema                                _recordSchema;
 
-	private String                   _compressionCodec;
-	private TypeDescriptor           _typeDescription;
+	private String                                          _compressionCodec;
+	private TypeDescriptor                                  _typeDescription;
 
 	protected GenericAvroSerializer (CodecFactory compressionCodec, TypeDescriptor typeDescription) {
 		_compressionCodec = codecToDescription(compressionCodec);
 		_typeDescription = typeDescription;
-		_tileSchema = new HashMap<>();
+		_tileSchema = null;
 		_recordSchema = null;
 	}
 
@@ -106,10 +107,17 @@ abstract public class GenericAvroSerializer<T> implements TileSerializer<T> {
 	}
 
 	protected Schema getTileSchema (StorageType storage) throws IOException {
-		if (!_tileSchema.containsKey(storage)) {
-			_tileSchema.put(storage, createTileSchema(storage));
+		if (null == _tileSchema)
+			_tileSchema = new ThreadLocal<Map<StorageType, Schema>>() {
+				@Override
+				protected Map<StorageType, Schema> initialValue () {
+					return new HashMap<TileData.StorageType, Schema>();
+				}
+			};
+		if (!_tileSchema.get().containsKey(storage)) {
+			_tileSchema.get().put(storage, createTileSchema(storage));
 		}
-		return _tileSchema.get(storage);
+		return _tileSchema.get().get(storage);
 	}
 	
 	protected Schema createTileSchema (StorageType storage) throws IOException {

--- a/binning-utilities/src/test/java/com/oculusinfo/binning/io/serialization/impl/SerializerSerializabilityTests.java
+++ b/binning-utilities/src/test/java/com/oculusinfo/binning/io/serialization/impl/SerializerSerializabilityTests.java
@@ -43,181 +43,205 @@ import com.oculusinfo.factory.util.Pair;
 import com.oculusinfo.binning.util.TypeDescriptor;
 
 public class SerializerSerializabilityTests {
-    @Test
-    public void testPrimitiveSerializer () throws Exception {
-        TileSerializer<Double> serialD = new PrimitiveAvroSerializer<>(Double.class, CodecFactory.nullCodec());
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        ObjectOutputStream oos = new ObjectOutputStream(baos);
-        oos.writeObject(serialD);
-        oos.flush();
-        oos.close();
-        baos.flush();
-        baos.close();
+	@Test
+	public void testPrimitiveSerializer () throws Exception {
+		TileSerializer<Double> serialD = new PrimitiveAvroSerializer<>(Double.class, CodecFactory.nullCodec());
 
-        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
-        ObjectInputStream ois = new ObjectInputStream(bais);
-        Object result = ois.readObject();
-        Assert.assertTrue(result instanceof PrimitiveAvroSerializer);
-        PrimitiveAvroSerializer<?> serialR = (PrimitiveAvroSerializer<?>) result;
-        Assert.assertEquals(new TypeDescriptor(Double.class), serialR.getBinTypeDescription());
-        @SuppressWarnings({ "unchecked", "rawtypes" })
-        PrimitiveAvroSerializer<Double> serialRD = (PrimitiveAvroSerializer) result;
+		// Actually use the serializer - the schema doesn't get populated until we do
+		ByteArrayOutputStream baosTile = new ByteArrayOutputStream();
+		serialD.serialize(new DenseTileData<Double>(new TileIndex(0, 0, 0, 1, 1), 0.0), baosTile);
+		baosTile.flush();
+		baosTile.close();
 
-        // Make sure they work the same
-        TileData<Double> tile = new DenseTileData<>(new TileIndex(0, 0, 0, 4, 4),
-                Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0,
-                              8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0));
+		// Now try serializing the serializer
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ObjectOutputStream oos = new ObjectOutputStream(baos);
+		oos.writeObject(serialD);
+		oos.flush();
+		oos.close();
+		baos.flush();
+		baos.close();
 
-        ByteArrayOutputStream tbaos1 = new ByteArrayOutputStream();
-        serialD.serialize(tile, tbaos1);
-        tbaos1.flush();
-        tbaos1.close();
+		ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+		ObjectInputStream ois = new ObjectInputStream(bais);
+		Object result = ois.readObject();
+		Assert.assertTrue(result instanceof PrimitiveAvroSerializer);
+		PrimitiveAvroSerializer<?> serialR = (PrimitiveAvroSerializer<?>) result;
+		Assert.assertEquals(new TypeDescriptor(Double.class), serialR.getBinTypeDescription());
+		@SuppressWarnings({ "unchecked", "rawtypes" })
+		PrimitiveAvroSerializer<Double> serialRD = (PrimitiveAvroSerializer) result;
 
-        ByteArrayOutputStream tbaos2 = new ByteArrayOutputStream();
-        serialRD.serialize(tile, tbaos2);
-        tbaos1.flush();
-        tbaos1.close();
+		// Make sure they work the same
+		TileData<Double> tile = new DenseTileData<>(new TileIndex(0, 0, 0, 4, 4),
+		                                            Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0,
+		                                                          8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0));
 
-        ByteArrayInputStream tbais1 = new ByteArrayInputStream(tbaos1.toByteArray());
-        TileData<Double> out1 = serialRD.deserialize(tile.getDefinition(), tbais1);
+		ByteArrayOutputStream tbaos1 = new ByteArrayOutputStream();
+		serialD.serialize(tile, tbaos1);
+		tbaos1.flush();
+		tbaos1.close();
 
-        ByteArrayInputStream tbais2 = new ByteArrayInputStream(tbaos1.toByteArray());
-        TileData<Double> out2 = serialD.deserialize(tile.getDefinition(), tbais2);
+		ByteArrayOutputStream tbaos2 = new ByteArrayOutputStream();
+		serialRD.serialize(tile, tbaos2);
+		tbaos1.flush();
+		tbaos1.close();
 
-        Assert.assertEquals(tile.getDefinition(), out1.getDefinition());
-        Assert.assertEquals(tile.getDefinition(), out2.getDefinition());
-        for (int x=0; x<4; ++x) {
-            for (int y=0; y<4; ++y) {
-                Assert.assertEquals(tile.getBin(x, y), out1.getBin(x, y), 1E-12);
-                Assert.assertEquals(tile.getBin(x, y), out2.getBin(x, y), 1E-12);
-            }
+		ByteArrayInputStream tbais1 = new ByteArrayInputStream(tbaos1.toByteArray());
+		TileData<Double> out1 = serialRD.deserialize(tile.getDefinition(), tbais1);
+
+		ByteArrayInputStream tbais2 = new ByteArrayInputStream(tbaos1.toByteArray());
+		TileData<Double> out2 = serialD.deserialize(tile.getDefinition(), tbais2);
+
+		Assert.assertEquals(tile.getDefinition(), out1.getDefinition());
+		Assert.assertEquals(tile.getDefinition(), out2.getDefinition());
+		for (int x=0; x<4; ++x) {
+			for (int y=0; y<4; ++y) {
+				Assert.assertEquals(tile.getBin(x, y), out1.getBin(x, y), 1E-12);
+				Assert.assertEquals(tile.getBin(x, y), out2.getBin(x, y), 1E-12);
+			}
         
-        }
+		}
         
-    }
+	}
 
-    @Test
-    public void testPrimitiveArraySerializer () throws Exception {
-        TileSerializer<List<Float>> serialD = new PrimitiveArrayAvroSerializer<>(Float.class, CodecFactory.nullCodec());
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        ObjectOutputStream oos = new ObjectOutputStream(baos);
-        oos.writeObject(serialD);
-        oos.flush();
-        oos.close();
-        baos.flush();
-        baos.close();
+	@Test
+	public void testPrimitiveArraySerializer () throws Exception {
+		TileSerializer<List<Float>> serialD = new PrimitiveArrayAvroSerializer<>(Float.class, CodecFactory.nullCodec());
 
-        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
-        ObjectInputStream ois = new ObjectInputStream(bais);
-        Object result = ois.readObject();
-        Assert.assertTrue(result instanceof PrimitiveArrayAvroSerializer);
-        PrimitiveArrayAvroSerializer<?> serialR = (PrimitiveArrayAvroSerializer<?>) result;
-        Assert.assertEquals(new TypeDescriptor(List.class, new TypeDescriptor(Float.class)), serialR.getBinTypeDescription());
-        @SuppressWarnings({ "unchecked", "rawtypes" })
-        PrimitiveArrayAvroSerializer<Float> serialRD = (PrimitiveArrayAvroSerializer) result;
+		// Actually use the serializer - the schema doesn't get populated until we do
+		ByteArrayOutputStream baosTile = new ByteArrayOutputStream();
+		serialD.serialize(new DenseTileData<List<Float>>(new TileIndex(0, 0, 0, 1, 1), Arrays.asList(0.0f)), baosTile);
+		baosTile.flush();
+		baosTile.close();
 
-        // Make sure they work the same
-        TileData<List<Float>> tile = new DenseTileData<>(new TileIndex(0, 0, 0, 2, 2),
-                Arrays.asList(Arrays.asList( 0.0f,  1.0f,  2.0f),
-                              Arrays.asList( 3.0f,  4.0f,  5.0f,  6.0f),
-                              Arrays.asList( 7.0f,  8.0f,  9.0f, 10.0f, 11.0f),
-                              Arrays.asList(12.0f, 13.0f, 14.0f, 15.0f, 16.0f, 17.0f)));
+		// Now try serializing the serializer
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ObjectOutputStream oos = new ObjectOutputStream(baos);
+		oos.writeObject(serialD);
+		oos.flush();
+		oos.close();
+		baos.flush();
+		baos.close();
 
-        ByteArrayOutputStream tbaos1 = new ByteArrayOutputStream();
-        serialD.serialize(tile, tbaos1);
-        tbaos1.flush();
-        tbaos1.close();
+		ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+		ObjectInputStream ois = new ObjectInputStream(bais);
+		Object result = ois.readObject();
+		Assert.assertTrue(result instanceof PrimitiveArrayAvroSerializer);
+		PrimitiveArrayAvroSerializer<?> serialR = (PrimitiveArrayAvroSerializer<?>) result;
+		Assert.assertEquals(new TypeDescriptor(List.class, new TypeDescriptor(Float.class)), serialR.getBinTypeDescription());
+		@SuppressWarnings({ "unchecked", "rawtypes" })
+		PrimitiveArrayAvroSerializer<Float> serialRD = (PrimitiveArrayAvroSerializer) result;
 
-        ByteArrayOutputStream tbaos2 = new ByteArrayOutputStream();
-        serialRD.serialize(tile, tbaos2);
-        tbaos1.flush();
-        tbaos1.close();
+		// Make sure they work the same
+		TileData<List<Float>> tile = new DenseTileData<>(new TileIndex(0, 0, 0, 2, 2),
+		                                                 Arrays.asList(Arrays.asList( 0.0f,  1.0f,  2.0f),
+		                                                               Arrays.asList( 3.0f,  4.0f,  5.0f,  6.0f),
+		                                                               Arrays.asList( 7.0f,  8.0f,  9.0f, 10.0f, 11.0f),
+		                                                               Arrays.asList(12.0f, 13.0f, 14.0f, 15.0f, 16.0f, 17.0f)));
 
-        ByteArrayInputStream tbais1 = new ByteArrayInputStream(tbaos1.toByteArray());
-        TileData<List<Float>> out1 = serialRD.deserialize(tile.getDefinition(), tbais1);
+		ByteArrayOutputStream tbaos1 = new ByteArrayOutputStream();
+		serialD.serialize(tile, tbaos1);
+		tbaos1.flush();
+		tbaos1.close();
 
-        ByteArrayInputStream tbais2 = new ByteArrayInputStream(tbaos1.toByteArray());
-        TileData<List<Float>> out2 = serialD.deserialize(tile.getDefinition(), tbais2);
+		ByteArrayOutputStream tbaos2 = new ByteArrayOutputStream();
+		serialRD.serialize(tile, tbaos2);
+		tbaos1.flush();
+		tbaos1.close();
 
-        Assert.assertEquals(tile.getDefinition(), out1.getDefinition());
-        Assert.assertEquals(tile.getDefinition(), out2.getDefinition());
-        for (int x=0; x<2; ++x) {
-            for (int y=0; y<2; ++y) {
-                List<Float> original = tile.getBin(x, y);
-                List<Float> copy1 = out1.getBin(x, y);
-                List<Float> copy2 = out2.getBin(x, y);
-                Assert.assertEquals(original.size(), copy1.size());
-                Assert.assertEquals(original.size(), copy2.size());
-                for (int z=0; z<original.size(); ++z) {
-                    Assert.assertEquals(original.get(z), copy1.get(z), 1E-12);
-                    Assert.assertEquals(original.get(z), copy2.get(z), 1E-12);
-                }
-            }
+		ByteArrayInputStream tbais1 = new ByteArrayInputStream(tbaos1.toByteArray());
+		TileData<List<Float>> out1 = serialRD.deserialize(tile.getDefinition(), tbais1);
+
+		ByteArrayInputStream tbais2 = new ByteArrayInputStream(tbaos1.toByteArray());
+		TileData<List<Float>> out2 = serialD.deserialize(tile.getDefinition(), tbais2);
+
+		Assert.assertEquals(tile.getDefinition(), out1.getDefinition());
+		Assert.assertEquals(tile.getDefinition(), out2.getDefinition());
+		for (int x=0; x<2; ++x) {
+			for (int y=0; y<2; ++y) {
+				List<Float> original = tile.getBin(x, y);
+				List<Float> copy1 = out1.getBin(x, y);
+				List<Float> copy2 = out2.getBin(x, y);
+				Assert.assertEquals(original.size(), copy1.size());
+				Assert.assertEquals(original.size(), copy2.size());
+				for (int z=0; z<original.size(); ++z) {
+					Assert.assertEquals(original.get(z), copy1.get(z), 1E-12);
+					Assert.assertEquals(original.get(z), copy2.get(z), 1E-12);
+				}
+			}
         
-        }
-    }
+		}
+	}
 
-    private <T, S> Pair<T, S> p (T t, S s) {
-        return new Pair<T, S>(t, s);
-    }
-    @Test
-    public void testPairArraySerializer () throws Exception {
-        TileSerializer<List<Pair<String, Integer>>> serialD = new PairArrayAvroSerializer<>(String.class, Integer.class, CodecFactory.nullCodec());
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        ObjectOutputStream oos = new ObjectOutputStream(baos);
-        oos.writeObject(serialD);
-        oos.flush();
-        oos.close();
-        baos.flush();
-        baos.close();
+	private <T, S> Pair<T, S> p (T t, S s) {
+		return new Pair<T, S>(t, s);
+	}
+	@Test
+	public void testPairArraySerializer () throws Exception {
+		TileSerializer<List<Pair<String, Integer>>> serialD = new PairArrayAvroSerializer<>(String.class, Integer.class, CodecFactory.nullCodec());
 
-        ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
-        ObjectInputStream ois = new ObjectInputStream(bais);
-        Object result = ois.readObject();
-        Assert.assertTrue(result instanceof PairArrayAvroSerializer);
-        PairArrayAvroSerializer<?, ?> serialR = (PairArrayAvroSerializer<?, ?>) result;
-        Assert.assertEquals(new TypeDescriptor(List.class, new TypeDescriptor(Pair.class, new TypeDescriptor(String.class), new TypeDescriptor(Integer.class))), serialR.getBinTypeDescription());
-        @SuppressWarnings({ "unchecked", "rawtypes" })
-        PairArrayAvroSerializer<String, Integer> serialRD = (PairArrayAvroSerializer) result;
+		// Actually use the serializer - the schema doesn't get populated until we do
+		ByteArrayOutputStream baosTile = new ByteArrayOutputStream();
+		serialD.serialize(new DenseTileData<List<Pair<String, Integer>>>(new TileIndex(0, 0, 0, 1, 1), Arrays.asList(new Pair<String, Integer>("a", 1))), baosTile);
+		baosTile.flush();
+		baosTile.close();
 
-        // Make sure they work the same
-        TileData<List<Pair<String, Integer>>> tile = new DenseTileData<>(new TileIndex(0, 0, 0, 2, 2),
-                Arrays.asList(Arrays.asList(p("a", 1)),
-                              Arrays.asList(p("b", 2), p("c", 3)),
-                              Arrays.asList(p("d", 4), p("e", 5), p("f", 6)),
-                              Arrays.asList(p("g", 7), p("h", 8), p("i", 9), p("j", 10))));
+		// Now try serializing the serializer
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		ObjectOutputStream oos = new ObjectOutputStream(baos);
+		oos.writeObject(serialD);
+		oos.flush();
+		oos.close();
+		baos.flush();
+		baos.close();
 
-        ByteArrayOutputStream tbaos1 = new ByteArrayOutputStream();
-        serialD.serialize(tile, tbaos1);
-        tbaos1.flush();
-        tbaos1.close();
+		ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+		ObjectInputStream ois = new ObjectInputStream(bais);
+		Object result = ois.readObject();
+		Assert.assertTrue(result instanceof PairArrayAvroSerializer);
+		PairArrayAvroSerializer<?, ?> serialR = (PairArrayAvroSerializer<?, ?>) result;
+		Assert.assertEquals(new TypeDescriptor(List.class, new TypeDescriptor(Pair.class, new TypeDescriptor(String.class), new TypeDescriptor(Integer.class))), serialR.getBinTypeDescription());
+		@SuppressWarnings({ "unchecked", "rawtypes" })
+		PairArrayAvroSerializer<String, Integer> serialRD = (PairArrayAvroSerializer) result;
 
-        ByteArrayOutputStream tbaos2 = new ByteArrayOutputStream();
-        serialRD.serialize(tile, tbaos2);
-        tbaos1.flush();
-        tbaos1.close();
+		// Make sure they work the same
+		TileData<List<Pair<String, Integer>>> tile = new DenseTileData<>(new TileIndex(0, 0, 0, 2, 2),
+		                                                                 Arrays.asList(Arrays.asList(p("a", 1)),
+			         Arrays.asList(p("b", 2), p("c", 3)),
+			         Arrays.asList(p("d", 4), p("e", 5), p("f", 6)),
+			         Arrays.asList(p("g", 7), p("h", 8), p("i", 9), p("j", 10))));
 
-        ByteArrayInputStream tbais1 = new ByteArrayInputStream(tbaos1.toByteArray());
-        TileData<List<Pair<String, Integer>>> out1 = serialRD.deserialize(tile.getDefinition(), tbais1);
+		ByteArrayOutputStream tbaos1 = new ByteArrayOutputStream();
+		serialD.serialize(tile, tbaos1);
+		tbaos1.flush();
+		tbaos1.close();
 
-        ByteArrayInputStream tbais2 = new ByteArrayInputStream(tbaos1.toByteArray());
-        TileData<List<Pair<String, Integer>>> out2 = serialD.deserialize(tile.getDefinition(), tbais2);
+		ByteArrayOutputStream tbaos2 = new ByteArrayOutputStream();
+		serialRD.serialize(tile, tbaos2);
+		tbaos1.flush();
+		tbaos1.close();
 
-        Assert.assertEquals(tile.getDefinition(), out1.getDefinition());
-        Assert.assertEquals(tile.getDefinition(), out2.getDefinition());
-        for (int x=0; x<2; ++x) {
-            for (int y=0; y<2; ++y) {
-                List<Pair<String, Integer>> original = tile.getBin(x, y);
-                List<Pair<String, Integer>> copy1 = out1.getBin(x, y);
-                List<Pair<String, Integer>> copy2 = out2.getBin(x, y);
-                Assert.assertEquals(original.size(), copy1.size());
-                Assert.assertEquals(original.size(), copy2.size());
-                for (int z=0; z<original.size(); ++z) {
-                    Assert.assertEquals(original.get(z), copy1.get(z));
-                    Assert.assertEquals(original.get(z), copy2.get(z));
-                }
-            }
+		ByteArrayInputStream tbais1 = new ByteArrayInputStream(tbaos1.toByteArray());
+		TileData<List<Pair<String, Integer>>> out1 = serialRD.deserialize(tile.getDefinition(), tbais1);
+
+		ByteArrayInputStream tbais2 = new ByteArrayInputStream(tbaos1.toByteArray());
+		TileData<List<Pair<String, Integer>>> out2 = serialD.deserialize(tile.getDefinition(), tbais2);
+
+		Assert.assertEquals(tile.getDefinition(), out1.getDefinition());
+		Assert.assertEquals(tile.getDefinition(), out2.getDefinition());
+		for (int x=0; x<2; ++x) {
+			for (int y=0; y<2; ++y) {
+				List<Pair<String, Integer>> original = tile.getBin(x, y);
+				List<Pair<String, Integer>> copy1 = out1.getBin(x, y);
+				List<Pair<String, Integer>> copy2 = out2.getBin(x, y);
+				Assert.assertEquals(original.size(), copy1.size());
+				Assert.assertEquals(original.size(), copy2.size());
+				for (int z=0; z<original.size(); ++z) {
+					Assert.assertEquals(original.get(z), copy1.get(z));
+					Assert.assertEquals(original.get(z), copy2.get(z));
+				}
+			}
         
-        }
-    }
+		}
+	}
 }


### PR DESCRIPTION
Fixed tests to work use serializers before trying to serialize them.
Make sure tests fail.
Fix serialization so tests succeed.

I have not made tests test serializer use across multiple threads.  That seems a separate test, and it would take a while to write, and Sean needs this ASAP (and will discover the issue immediately if it exists).

Fixes #162.