### PR TITLE
Direct initialization of the old on-demand tiling method

### DIFF
--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/binning/OnDemandAccumulatorPyramidIO.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/binning/OnDemandAccumulatorPyramidIO.scala
@@ -124,6 +124,11 @@ class OnDemandAccumulatorPyramidIO (sqlc: SQLContext) extends PyramidIO with Log
 		}
 	}
 
+	/**
+	 * Direct programatic initialization.
+	 * 
+	 * Temporary route until we get full pipeline configuration
+	 */
 	def initializeDirectly (pyramidId: String, task: TilingTask[_, _, _, _]): Unit ={
 		if (!tasks.contains(pyramidId)) {
 			tasks.synchronized {

--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/binning/OnDemandBinningPyramidIO.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/binning/OnDemandBinningPyramidIO.scala
@@ -174,6 +174,23 @@ class OnDemandBinningPyramidIO (sqlc: SQLContext) extends PyramidIO {
 		}
 	}
 
+	/**
+	 * Direct programatic initialization.
+	 * 
+	 * Temporary route until we get full pipeline configuration
+	 */
+	def initializeDirectly (pyramidId: String, task: TilingTask[_, _, _, _]): Unit ={
+		if (!tasks.contains(pyramidId)) {
+			tasks.synchronized {
+				if (!tasks.contains(pyramidId)) {
+					task.getTileAnalytics.map(_.addGlobalAccumulator(sc))
+					task.getDataAnalytics.map(_.addGlobalAccumulator(sc))
+					tasks(pyramidId) = task
+				}
+			}
+		}
+	}
+
 	def readTiles[BT] (pyramidId: String,
 	                   serializer: TileSerializer[BT],
 	                   javaTiles: JavaIterable[TileIndex]):


### PR DESCRIPTION
We need this for timing on-demand tiling for now.
It should be temporary - when pipeline initialization is finished, we shouldn't need this any more.