### PR TITLE
Fix for tile-generation metadata.

### DIFF
--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/tiling/HBaseTileIO.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/tiling/HBaseTileIO.scala
@@ -232,16 +232,16 @@ class HBaseTileIO (zookeeperQuorum: String,
 
 		// Don't alter metadata if there was no data added.
 		// Ideally, we'd still alter levels
-		if (tileCount.value > 0) {
-			println("Calculating metadata")
-			val metaData =
-				combineMetaData(pyramider, baseLocation,
-				                levelSet.value.toSet,
-				                tileAnalytics, dataAnalytics,
-				                xbins.value, ybins.value,
-				                name, description)
-			writeMetaData(baseLocation, metaData)
-		}
+
+		println("Calculating metadata")
+		val metaData =
+			combineMetaData(pyramider, baseLocation,
+											levelSet.value.toSet,
+											tileAnalytics, dataAnalytics,
+											xbins.value, ybins.value,
+											name, description)
+		writeMetaData(baseLocation, metaData)
+
 	}
 }
 

--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/tiling/SequenceFileTileIO.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/tiling/SequenceFileTileIO.scala
@@ -223,15 +223,13 @@ class SequenceFileTileIO (connection: String) extends TileIO {
 
 		// Don't alter metadata if there was no data added.
 		// Ideally, we'd still alter levels
-		if (tileCount.value > 0) {
-			val metaData =
-				combineMetaData(pyramider, baseLocation,
-				                levelSet.value.toSet,
-				                tileAnalytics, dataAnalytics,
-				                xbins.value, ybins.value,
-				                name, description)
-			writeMetaData(baseLocation, metaData)
-		}
+		val metaData =
+			combineMetaData(pyramider, baseLocation,
+											levelSet.value.toSet,
+											tileAnalytics, dataAnalytics,
+											xbins.value, ybins.value,
+											name, description)
+		writeMetaData(baseLocation, metaData)
 	}
 
 	override def readMetaData (baseLocation: String): Option[PyramidMetaData] = {

--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/tiling/TileIO.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/tiling/TileIO.scala
@@ -198,17 +198,15 @@ trait TileIO extends Serializable {
 
 		// Don't alter metadata if there was no data added.
 		// Ideally, we'd still alter levels.
-		if (tileCount.value > 0) {
-			val metaData =
-				combineMetaData(pyramider, baseLocation,
-				                levelSet.value.toSet,
-				                tileAnalytics, dataAnalytics,
-				                xbins.value, ybins.value,
-				                name, description)
-			writeMetaData(baseLocation, metaData)
-		}
+		val metaData =
+			combineMetaData(pyramider, baseLocation,
+											levelSet.value.toSet,
+											tileAnalytics, dataAnalytics,
+											xbins.value, ybins.value,
+											name, description)
+		writeMetaData(baseLocation, metaData)
 	}
-	
+
 	/**
 	 * Takes a map of levels to (mins, maxes) and combines them with the current metadata
 	 * that already exists, or creates a new one if none exists.


### PR DESCRIPTION
Metadata is now created and written even if 0 tiles are generated.