### PR TITLE
Time-based tile rendering - added a new time based filter tr...

### DIFF
--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/impl/DoubleListHeatMapImageRenderer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/impl/DoubleListHeatMapImageRenderer.java
@@ -53,7 +53,7 @@ import com.oculusinfo.factory.properties.StringProperty;
  * @author mkielo
  */
 
-public class DoubleListHeatMapImageRenderer implements TileDataImageRenderer<List<Double>> {
+public class DoubleListHeatMapImageRenderer implements TileDataImageRenderer<List<Number>> {
 	private final Logger LOGGER = LoggerFactory.getLogger(getClass());
 
 	private static final Color COLOR_BLANK = new Color(255,255,255,0);
@@ -61,7 +61,7 @@ public class DoubleListHeatMapImageRenderer implements TileDataImageRenderer<Lis
     // This is the only way to get a generified class; because of type erasure,
     // it is definitionally accurate.
     @SuppressWarnings({ "unchecked", "rawtypes" })
-    public Class<List<Double>> getAcceptedBinClass () {
+    public Class<List<Number>> getAcceptedBinClass () {
         return (Class) List.class;
     }
 
@@ -93,7 +93,7 @@ public class DoubleListHeatMapImageRenderer implements TileDataImageRenderer<Lis
 	/* (non-Javadoc)
 	 * @see TileDataImageRenderer#render(LayerConfiguration)
 	 */
-    public BufferedImage render (TileData<List<Double>> data, LayerConfiguration config) {
+    public BufferedImage render (TileData<List<Number>> data, LayerConfiguration config) {
         BufferedImage bi;
         String layerId = config.getPropertyValue(LayerConfiguration.LAYER_ID);
         TileIndex index = config.getPropertyValue(LayerConfiguration.TILE_COORDINATE);
@@ -106,7 +106,7 @@ public class DoubleListHeatMapImageRenderer implements TileDataImageRenderer<Lis
             bi = new BufferedImage(outputWidth, outputHeight, BufferedImage.TYPE_INT_ARGB);
 
             @SuppressWarnings("unchecked")
-            ValueTransformer<Double> t = config.produce(ValueTransformer.class);
+            ValueTransformer<Number> t = config.produce(ValueTransformer.class);
             int[] rgbArray = new int[outputWidth*outputHeight];
 
             double scaledMax = (double)rangeMax/100;
@@ -114,8 +114,8 @@ public class DoubleListHeatMapImageRenderer implements TileDataImageRenderer<Lis
             double oneOverScaledRange = 1.0 / (scaledMax - scaledMin);
 
             @SuppressWarnings("unchecked")
-            TileTransformer<List<Double>> tileTransformer = config.produce(TileTransformer.class);
-            TileData<List<Double>> transformedContents = tileTransformer.transform( data );
+            TileTransformer<List<Number>> tileTransformer = config.produce(TileTransformer.class);
+            TileData<List<Number>> transformedContents = tileTransformer.transform( data );
 
             int xBins = data.getDefinition().getXBins();
             int yBins = data.getDefinition().getYBins();
@@ -132,17 +132,19 @@ public class DoubleListHeatMapImageRenderer implements TileDataImageRenderer<Lis
                     int minY = (int) Math.round(ty*yScale);
                     int maxY = (int) Math.round((ty+1)*yScale);
 
-                    List<Double> binContents = transformedContents.getBin(tx, ty);
-                    double binCount = 0;
-                    for(int i = 0; i < binContents.size(); i++){
-                        binCount = binCount + binContents.get(i);
+                    List<Number> binContents = transformedContents.getBin(tx, ty);
+                    Number binCount = 0;
+                    for(int i = 0; i < binContents.size(); i++) {
+                    	if ( binContents.get(i) != null ) {
+                    		binCount = binCount.doubleValue() + binContents.get(i).doubleValue();
+                    	}
                     }
 
                     //log/linear
-                    double transformedValue = t.transform(binCount);
+                    Number transformedValue = t.transform(binCount.doubleValue());
                     int rgb;
-                    if (binCount > 0) {
-                        rgb = colorRamp.getRGB( ( transformedValue - scaledMin ) * oneOverScaledRange );
+                    if (binCount.doubleValue() > 0) {
+                        rgb = colorRamp.getRGB( ( transformedValue.doubleValue() - scaledMin ) * oneOverScaledRange );
                     } else {
                         rgb = COLOR_BLANK.getRGB();
                     }
@@ -155,7 +157,6 @@ public class DoubleListHeatMapImageRenderer implements TileDataImageRenderer<Lis
                         }
                     }
                 }
-
             }
 
             bi.setRGB(0, 0, outputWidth, outputHeight, rgbArray, 0, outputWidth);

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/FilterByBucketTileTransformer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/FilterByBucketTileTransformer.java
@@ -46,20 +46,20 @@ import org.json.JSONObject;
  * 
  */
 
-public class FilterByTimeTileTransformer<T> implements TileTransformer<List<T>> {
-	private static final Logger LOGGER = LoggerFactory.getLogger(FilterByTimeTileTransformer.class);
+public class FilterByBucketTileTransformer<T> implements TileTransformer<List<T>> {
+	private static final Logger LOGGER = LoggerFactory.getLogger(FilterByBucketTileTransformer.class);
 	
-	private int _startTimeBucket = 0;
-	private int _endTimeBucket = 0;
-	private int _totalTimeBuckets = 0;
+	private int _startBucket = 0;
+	private int _endBucket   = 0;
+	private int _bucketCount = 0;
 	
-	public FilterByTimeTileTransformer(JSONObject arguments){
+	public FilterByBucketTileTransformer(JSONObject arguments){
 		try {
 			if (arguments != null) {
 				// get the start and end time range
-				_startTimeBucket = arguments.getInt("startTimeBucket");
-				_endTimeBucket = arguments.getInt("endTimeBucket");
-				_totalTimeBuckets = arguments.getInt("totalTimeBuckets");
+				_startBucket = arguments.getInt("startBucket");
+				_endBucket   = arguments.getInt("endBucket");
+				_bucketCount = arguments.getInt("bucketCount");
 			}
 		}
 		catch (JSONException e) {
@@ -85,8 +85,8 @@ public class FilterByTimeTileTransformer<T> implements TileTransformer<List<T>> 
 
     	TileData<List<T>> resultTile = null;
         
-        if ( _startTimeBucket < 0 || _startTimeBucket > _endTimeBucket || _endTimeBucket > _totalTimeBuckets ) { 
-			throw new IllegalArgumentException("Filter by time transformer arguments are invalid.  start time bucket: " + _startTimeBucket + ", end time bucket: " + _endTimeBucket);
+        if ( _startBucket < 0 || _startBucket > _endBucket || _endBucket > _bucketCount ) { 
+			throw new IllegalArgumentException("Filter by time transformer arguments are invalid.  start time bucket: " + _startBucket + ", end time bucket: " + _endBucket);
         }      
 
         int xBins = inputData.getDefinition().getXBins();
@@ -101,9 +101,9 @@ public class FilterByTimeTileTransformer<T> implements TileTransformer<List<T>> 
                 int binSize = binContents.size();
                 
                 // make sure we have a full array to add into the tile for dense tile creation
-                List<T> transformedBin = new ArrayList<>(_totalTimeBuckets);
+                List<T> transformedBin = new ArrayList<>(_bucketCount);
                 for(int i = 0; i < binSize; i++) {
-                    if ( i >= _startTimeBucket && i <= _endTimeBucket ) {
+                    if ( i >= _startBucket && i <= _endBucket ) {
                     	transformedBin.add(i, binContents.get(i));
                     } else {
                     	transformedBin.add(i, null);

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/FilterByTimeTileTransformer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/FilterByTimeTileTransformer.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2015 Uncharted Software. 
+ * http://www.oculusinfo.com/
+ * 
+ * Released under the MIT License.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.oculusinfo.tile.rendering.transformations.tile;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import com.oculusinfo.binning.TileData;
+import com.oculusinfo.binning.TileIndex;
+import com.oculusinfo.binning.impl.DenseTileData;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+
+/** 
+ * 	This transformer will take in JSON or tileData object representing bins of a double array  
+ * 		tile and will filter out all counts in the bins representing the time buckets indicated
+ * 		in the configuration.  The double arrays passed back will be in the order that they are 
+ * 		sequenced in the JSON/Tile array passed in.
+ * 
+ */
+
+public class FilterByTimeTileTransformer<T> implements TileTransformer<List<T>> {
+	private static final Logger LOGGER = LoggerFactory.getLogger(FilterByTimeTileTransformer.class);
+	
+	private int _startTimeBucket = 0;
+	private int _endTimeBucket = 0;
+	private int _totalTimeBuckets = 0;
+	
+	public FilterByTimeTileTransformer(JSONObject arguments){
+		try {
+			if (arguments != null) {
+				// get the start and end time range
+				_startTimeBucket = arguments.getInt("startTimeBucket");
+				_endTimeBucket = arguments.getInt("endTimeBucket");
+				_totalTimeBuckets = arguments.getInt("totalTimeBuckets");
+			}
+		}
+		catch (JSONException e) {
+			LOGGER.warn("Exception getting arguments for filter by time tile transformer", e);
+		}
+	}
+
+	
+	@Override
+	public JSONObject transform (JSONObject inputJSON) throws JSONException {
+		return inputJSON; // not implemented 
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see com.oculusinfo.tile.rendering.transformations.tile.TileTransformer#transform(com.oculusinfo.binning.TileData)
+	 * 
+	 * Note: This transformer explicitly transforms all tiles into a dense tile format.  If a sparse tile is 
+	 * 			passed in, the values not explicitly represented will be set to null.
+	 */
+    @Override
+    public TileData<List<T>> transform (TileData<List<T>> inputData) throws Exception {
+
+    	TileData<List<T>> resultTile = null;
+        
+        if ( _startTimeBucket < 0 || _startTimeBucket > _endTimeBucket || _endTimeBucket > _totalTimeBuckets ) { 
+			throw new IllegalArgumentException("Filter by time transformer arguments are invalid.  start time bucket: " + _startTimeBucket + ", end time bucket: " + _endTimeBucket);
+        }      
+
+        int xBins = inputData.getDefinition().getXBins();
+        int yBins = inputData.getDefinition().getYBins();
+        
+        TileIndex index = inputData.getDefinition();
+		List<List<T>> transformedData = new ArrayList<>(index.getXBins()*index.getYBins());
+
+        for(int ty = 0; ty < yBins; ty++){
+            for(int tx = 0; tx < xBins; tx++){
+                List<T> binContents = inputData.getBin(tx, ty);
+                int binSize = binContents.size();
+                
+                // make sure we have a full array to add into the tile for dense tile creation
+                List<T> transformedBin = new ArrayList<>(_totalTimeBuckets);
+                for(int i = 0; i < binSize; i++) {
+                    if ( i >= _startTimeBucket && i <= _endTimeBucket ) {
+                    	transformedBin.add(i, binContents.get(i));
+                    } else {
+                    	transformedBin.add(i, null);
+                    }
+                }
+                transformedData.add(transformedBin);
+            }
+        }
+
+        resultTile = new DenseTileData<>(inputData.getDefinition(), transformedData);
+        
+        // add in metadata to the tile
+        Collection<String> keys = inputData.getMetaDataProperties();
+		if (null != keys && !keys.isEmpty()) {
+			for (String key: keys) {
+			String value = inputData.getMetaData(key);
+			if (null != value)
+				resultTile.setMetaData(key, value);
+			}
+		}
+
+        return resultTile;
+    }
+
+}

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/FilterVarsDoubleArrayTileTransformer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/FilterVarsDoubleArrayTileTransformer.java
@@ -39,10 +39,10 @@ import org.json.JSONObject;
 
 
 /** 
- * 	This transformer will take in JSON object representing bins of a double array tile and
- * 		will filter out all variables except the variables contained in the variable
+ * 	This transformer will take in JSON or tileData object representing bins of a double array 
+ * 		tile and will filter out all variables except the variables contained in the variable
  * 		array passed in during construction.  The double arrays passed back will be in the 
- * 		order that they are sequenced in the JSON array passed in through the constructor.
+ * 		order that they are sequenced in the JSON or tileData array passed in.
  * 
  */
 

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/TileTransformerFactory.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/TileTransformerFactory.java
@@ -81,6 +81,10 @@ public class TileTransformerFactory extends ConfigurableFactory<TileTransformer<
 			JSONObject variables = getPropertyValue(INITIALIZATION_DATA);
 			return new FilterVarsDoubleArrayTileTransformer<Object>(variables);
 		}
+		if("filtertime".equals(transformerTypes)) {
+			JSONObject arguments = getPropertyValue(INITIALIZATION_DATA);
+			return new FilterByTimeTileTransformer<Object>(arguments);
+		}
 		else {  // 'identity' or none passed in will give the default transformer
 			return new IdentityTileTransformer<Object>();
 		}

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/TileTransformerFactory.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/TileTransformerFactory.java
@@ -83,7 +83,7 @@ public class TileTransformerFactory extends ConfigurableFactory<TileTransformer<
 		}
 		if("filtertime".equals(transformerTypes)) {
 			JSONObject arguments = getPropertyValue(INITIALIZATION_DATA);
-			return new FilterByTimeTileTransformer<Object>(arguments);
+			return new FilterByBucketTileTransformer<Object>(arguments);
 		}
 		else {  // 'identity' or none passed in will give the default transformer
 			return new IdentityTileTransformer<Object>();


### PR DESCRIPTION
...ansformer in conjuction with the DoubleListHeatMapImageRenderer in order to filter time ranges(buckets) used to determine heatmap values.  Updated DoubleListHeatMapImageRenderer to use Number instead of Double when processing tiles as well as taking into account null values in the tileData.  Null values in the tileData was necessary as the filter only deals with the templated value within the data and cannot just be Zeroed out.