### PR TITLE
Adding option to RDDLineBinner to draw 'directed arcs'.

### DIFF
--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/examples/apps/CSVGraphBinner.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/examples/apps/CSVGraphBinner.scala
@@ -144,6 +144,7 @@ object CSVGraphBinner {
 	private var _lineMaxBins = 1024		// [bins] max line segment length for a given level.
 	private var _bDrawLineEnds = false	// [Boolean] switch to draw just the ends of very long line segments
 	private var _bLinesAsArcs = false	// [Boolean] switch to draw line segments as straight lines (default) or as clock-wise arcs.
+	private var _bDrawDirectedArcs = false	// [Boolean] switch to draw directed arcs (direction is inferred by clock-wise curve of arc)
 
 	def processTask[PT: ClassTag,
 	                   DT: ClassTag,
@@ -213,7 +214,8 @@ object CSVGraphBinner {
 						                                      task.getTileType,
 						                                      calcLinePixels,
 						                                      bUsePointBinner,
-						                                      _bLinesAsArcs)
+						                                      _bLinesAsArcs,
+										 															_bDrawDirectedArcs)
 						tileIO.writeTileSet(task.getTilePyramid,
 						                    task.getName,
 						                    tiles,
@@ -345,6 +347,9 @@ object CSVGraphBinner {
 			
 			// Draw line segments as straight lines (default) or as clock-wise arcs.
 			_bLinesAsArcs = Try(props.getProperty("oculus.binning.line.style.arcs").toBoolean).getOrElse(false)
+
+			// Draw directed arcs instead of undirected (direction is inferred by clockwise curve of arc)
+			_bDrawDirectedArcs = Try(props.getProperty("oculus.binning.line.directed.arcs").toBoolean).getOrElse(false)
 
 			// check if hierarchical mode is enabled
 			var valTemp = props.getProperty("oculus.binning.hierarchical.clusters","false");

--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/tiling/RDDLineBinner.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/tiling/RDDLineBinner.scala
@@ -285,7 +285,8 @@ class RDDLineBinner(minBins: Int = 2,
 		 calcLinePixels: (BinIndex, BinIndex, PT) => IndexedSeq[(BinIndex, PT)]	=
 			 new EndPointsToLine().endpointsToLineBins,
 		 usePointBinner: Boolean = true,
-		 linesAsArcs: Boolean = false):
+		 linesAsArcs: Boolean = false,
+		 drawDirectedArcs: Boolean = false):
 			RDD[TileData[BT]] =
 	{
 		val tileBinToUniBin = (TileIndex.tileBinIndexToUniversalBinIndex)_
@@ -326,15 +327,19 @@ class RDDLineBinner(minBins: Int = 2,
 								(null, null, null)
 							} else {
 								// return endpoints as pair of universal bins per
-								// level
-								if (unvBin1.getX() < unvBin2.getX())
-								// use convention of endpoint with min X value
-								// is listed first
+								// level (note, we need one of the tile indices here
+								// to keep level info for this line segment)
+								if (linesAsArcs && drawDirectedArcs) {
 									(unvBin1, unvBin2, tile1)
-								else
-								// note, we need one of the tile indices here
-								// to keep level info for this line segment
-									(unvBin2, unvBin1, tile2)
+								}
+								else {
+									// If not drawing directed CW arcs, then use convention
+									// of endpoint with min X value listed first
+									if (unvBin1.getX() < unvBin2.getX())
+										(unvBin1, unvBin2, tile1)
+									else
+										(unvBin2, unvBin1, tile2)
+								}
 							}
 						}
 					}


### PR DESCRIPTION
Adding option to RDDLineBinner to draw 'directed arcs' using new oculus.binning.line.directed.arcs bd file option.

By default, arcs between two points are drawn along the same path, regardless of direction (ie undirected), to minimize the 'hair ball' effect when drawing lots of lines/trails.  This change allows directed arcs to be drawn using clock-wise arc convention as used in general Graph Theory (arc flow follows a CW path from source to destination).