### PR TITLE
Heatmap 'pixels' now rendered as circles instead of squares when coarsen...

### DIFF
--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/LayerConfiguration.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/LayerConfiguration.java
@@ -89,6 +89,9 @@ public class LayerConfiguration extends ConfigurableFactory<LayerConfiguration> 
 	public static final IntegerProperty COARSENESS = new IntegerProperty("coarseness",
 	    "Used by the standard heatmap renderer to allow the client to specify getting coarser tiles than needed, for efficiency (if needed)",
 	    1);
+	public static final StringProperty PIXEL_SHAPE = new StringProperty("pixelShape",
+		    "Used by the standard heatmap renderer to allow either circular or square 'pixels' if coarseness > 2x2. Valid settings are 'circle' (default) or 'square'.",
+		    "circle");	
 	public static final IntegerProperty OUTPUT_WIDTH = new IntegerProperty("outputWidth",
 	    "The output image width, defaults to the standard 256",
 	    256);
@@ -155,6 +158,7 @@ public class LayerConfiguration extends ConfigurableFactory<LayerConfiguration> 
 		addProperty(OUTPUT_HEIGHT);
         addProperty(DATA_ID, DATA_PATH);
 		addProperty(COARSENESS, RENDERER_PATH);
+		addProperty(PIXEL_SHAPE, RENDERER_PATH);
 		addProperty(RANGE_MIN, RENDERER_PATH);
 		addProperty(RANGE_MAX, RENDERER_PATH);
 		addProperty(RANGE_MODE, RENDERER_PATH);

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/impl/NumberImageRenderer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/impl/NumberImageRenderer.java
@@ -48,7 +48,8 @@ import java.awt.image.DataBufferInt;
 public class NumberImageRenderer implements TileDataImageRenderer<Number> {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(NumberImageRenderer.class);
-	private static final Color COLOR_BLANK = new Color(255,255,255,0);
+	private static final Color COLOR_BLANK = new Color(255,255,255,0);	
+	private static final double pow2(double x) { return x*x; }	//in-line func for squaring a number (instead of calling Math.pow(x, 2.0) 
 
 	@Override
 	public Class<Number> getAcceptedBinClass () {
@@ -95,6 +96,7 @@ public class NumberImageRenderer implements TileDataImageRenderer<Number> {
 			int rangeMax = config.getPropertyValue(LayerConfiguration.RANGE_MAX);
 			int rangeMin = config.getPropertyValue(LayerConfiguration.RANGE_MIN);
 			String rangeMode = config.getPropertyValue(LayerConfiguration.RANGE_MODE);
+			String pixelShape = config.getPropertyValue(LayerConfiguration.PIXEL_SHAPE);
 
 			// This is the best we can do; supress the warning and move on.
 			@SuppressWarnings("unchecked")
@@ -104,7 +106,7 @@ public class NumberImageRenderer implements TileDataImageRenderer<Number> {
 
 			ColorRamp colorRamp = config.produce(ColorRamp.class);
 
-			bi = renderImage(data, t, scaledMin, scaledMax, rangeMode, colorRamp, bi);
+			bi = renderImage(data, t, scaledMin, scaledMax, rangeMode, colorRamp, bi, pixelShape);
 		} catch (Exception e) {
 			LOGGER.warn("Configuration error: ", e);
 			return null;
@@ -115,7 +117,7 @@ public class NumberImageRenderer implements TileDataImageRenderer<Number> {
 
 	protected BufferedImage renderImage(TileData<Number> data,
 								   ValueTransformer<Number> t, double valueMin, double valueMax,
-								   String mode, ColorRamp colorRamp, BufferedImage bi) {
+								   String mode, ColorRamp colorRamp, BufferedImage bi, String pixelShape) {
 
 		int outWidth = bi.getWidth();
 		int outHeight = bi.getHeight();
@@ -124,45 +126,101 @@ public class NumberImageRenderer implements TileDataImageRenderer<Number> {
 
 		float xScale = outWidth / xBins;
 		float yScale = outHeight / yBins;
+		double radius2 = pow2(Math.min(xScale, yScale)*0.5);	// min squared 'radius' of final scaled bin
 
 		double oneOverScaledRange = 1.0 / (valueMax - valueMin);
-
+		boolean bCoarseCircles = pixelShape.equals("circle");	// render 'coarse' bins as circles or squares?
+		
 		int[] rgbArray = ((DataBufferInt)bi.getRaster().getDataBuffer()).getData();
+		
+		if ((xScale==1.0) && (yScale==1.0)) {
+			// no bin scaling needed
 
-		for(int ty = 0; ty < yBins; ty++){
-			for(int tx = 0; tx < xBins; tx++){
-				//calculate the scaled dimensions of this 'pixel' within the image
-				int minX = (int) Math.round(tx*xScale);
-				int maxX = (int) Math.round((tx+1)*xScale);
-				int minY = (int) Math.round(ty*yScale);
-				int maxY = (int) Math.round((ty+1)*yScale);
+			for(int ty = 0; ty < yBins; ty++){
+				for(int tx = 0; tx < xBins; tx++){
 
-				double binCount = data.getBin(tx, ty).doubleValue();
-				double transformedValue = t.transform(binCount).doubleValue();
-				int rgb;
+					double binCount = data.getBin(tx, ty).doubleValue();
+					double transformedValue = t.transform(binCount).doubleValue();
+					int rgb;
 
-				if (binCount > 0) {
-					if ( mode.equals("cull") ) {
-						if ( transformedValue >= valueMin && transformedValue <= valueMax ) {
-							rgb = colorRamp.getRGB( ( transformedValue - valueMin ) * oneOverScaledRange );
+					if (binCount > 0) {
+						if ( mode.equals("cull") ) {
+							if ( transformedValue >= valueMin && transformedValue <= valueMax ) {
+								rgb = colorRamp.getRGB( ( transformedValue - valueMin ) * oneOverScaledRange );
+							} else {
+								rgb = COLOR_BLANK.getRGB();
+							}
 						} else {
-							rgb = COLOR_BLANK.getRGB();
+							rgb = colorRamp.getRGB( ( transformedValue - valueMin ) * oneOverScaledRange );
 						}
 					} else {
-						rgb = colorRamp.getRGB( ( transformedValue - valueMin ) * oneOverScaledRange );
+						rgb = COLOR_BLANK.getRGB();
 					}
-				} else {
-					rgb = COLOR_BLANK.getRGB();
+					
+					//'draw' out the scaled 'pixel'
+					int i = ty*outWidth + tx;
+					rgbArray[i] = rgb;
 				}
+			}						
+		}
+		else {
+			// perform bin scaling (i.e. if bin coarseness != 1.0)
+			
+			for(int ty = 0; ty < yBins; ty++){
+				for(int tx = 0; tx < xBins; tx++){
+					//calculate the scaled dimensions of this 'pixel' within the image
+					int minX = (int) Math.round(tx*xScale);
+					int maxX = (int) Math.round((tx+1)*xScale);
+					int minY = (int) Math.round(ty*yScale);
+					int maxY = (int) Math.round((ty+1)*yScale);					
+					double centreX = (maxX + minX) * 0.5;
+					double centreY = (maxY + minY) * 0.5;
+					//double radius2 = (maxX - centreX)*(maxX - centreX);	// squared radius 
 
-				//'draw' out the scaled 'pixel'
-				for (int ix = minX; ix < maxX; ++ix) {
-					for (int iy = minY; iy < maxY; ++iy) {
-						int i = iy*outWidth + ix;
-						rgbArray[i] = rgb;
+					double binCount = data.getBin(tx, ty).doubleValue();
+					double transformedValue = t.transform(binCount).doubleValue();
+					int rgb;
+
+					if (binCount > 0) {
+						if ( mode.equals("cull") ) {
+							if ( transformedValue >= valueMin && transformedValue <= valueMax ) {
+								rgb = colorRamp.getRGB( ( transformedValue - valueMin ) * oneOverScaledRange );
+							} else {
+								rgb = COLOR_BLANK.getRGB();
+							}
+						} else {
+							rgb = colorRamp.getRGB( ( transformedValue - valueMin ) * oneOverScaledRange );
+						}
+					} else {
+						rgb = COLOR_BLANK.getRGB();
+					}
+
+					//'draw' out the scaled 'pixel'
+					if (bCoarseCircles && radius2 > 1.0) {
+						// draw scaled (coarse) bin as a circle (Note: need radius to be > 1.0 pixels in order to render a circle)
+						for (int ix = minX; ix < maxX; ++ix) {
+							for (int iy = minY; iy < maxY; ++iy) {							
+								int i = iy*outWidth + ix;
+								double dist = (pow2(ix+0.5-centreX) + pow2(iy+0.5-centreY));
+								if (dist <= radius2) {
+									rgbArray[i] = rgb;		// scaled bin is within bin's valid radius, so render normally
+								} else {
+									rgbArray[i] = COLOR_BLANK.getRGB();	// scaled bin is outside bin's valid radius, so force to be blank
+								}
+							}
+						}										
+					}
+					else {
+						// draw scaled bin simply as a square
+						for (int ix = minX; ix < maxX; ++ix) {
+							for (int iy = minY; iy < maxY; ++iy) {
+								int i = iy*outWidth + ix;
+								rgbArray[i] = rgb;
+							}
+						}
 					}
 				}
-			}
+			}			
 		}
 
 		return bi;


### PR DESCRIPTION
...ess > 2x2

Pixel shape can be tuned by client using the 'pixelShape' renderer property (valid options are 'circle' or 'square').