### PR TITLE
adds optional repartitioning to load ops

### DIFF
--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/pipeline/PipelineOperations.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/pipeline/PipelineOperations.scala
@@ -64,7 +64,7 @@ object PipelineOperations {
 
 	/**
 	 * Load data into the pipeline directly from a schema rdd
-	 * 
+	 *
 	 * @param rdd The SchemaRDD containing the data
 	 * @param tableName The name of the table the rdd has been assigned in the SQLContext, if any.
 	 */
@@ -82,7 +82,7 @@ object PipelineOperations {
 	 */
 	def loadJsonDataOp(path: String, partitions: Option[Int] = None)(data: PipelineData): PipelineData = {
 		val srdd = data.sqlContext.jsonFile(path)
-		val partitioned = partitions.map(srdd.repartition(_)).getOrElse(srdd)
+		val partitioned = partitions.map(n => srdd.coalesce(n, n > srdd.partitions.size)).getOrElse(srdd)
 		PipelineData(data.sqlContext, partitioned)
 	}
 
@@ -101,7 +101,7 @@ object PipelineOperations {
 	                 (data: PipelineData): PipelineData = {
 		val reader = new CSVReader(data.sqlContext, path, argumentSource)
 		val srdd = reader.asSchemaRDD
-		val partitioned = partitions.map(srdd.repartition(_)).getOrElse(srdd)
+		val partitioned = partitions.map(n => srdd.coalesce(n, n > srdd.partitions.size)).getOrElse(srdd)
 		PipelineData(reader.sqlc, partitioned)
 	}
 

--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/pipeline/PipelineOperationsParsing.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/pipeline/PipelineOperationsParsing.scala
@@ -73,12 +73,14 @@ object PipelineOperationsParsing extends Logging {
 	 *
 	 * Arguments:
 	 *    ops.path - Valid HDFS path to data.
+	 *    ops.partitions - Number of partitions
 	 */
 	def parseLoadJsonDataOp(args: Map[String, String]) = {
 		logger.debug(s"Parsing loadJsonDataOp with args $args")
 		val argParser = KeyValuePassthrough(args)
 		val path = argParser.getString("ops.path", "HDFS path to data")
-		loadJsonDataOp(path)(_)
+		val partitions = argParser.getIntOption("ops.partitions", "Number of data partitions")
+		loadJsonDataOp(path, partitions)(_)
 	}
 
 	/**
@@ -87,6 +89,7 @@ object PipelineOperationsParsing extends Logging {
 	 *
 	 * Arguments:
 	 *    ops.path - Valid HDFS path to data.
+	 *    ops.partitions - Number of partitions
 	 *
 	 * @see com.oculusinfo.tilegen.datasets.CSVReader for arguments passed into the CSV reader.
 	 *
@@ -95,7 +98,8 @@ object PipelineOperationsParsing extends Logging {
 		logger.debug(s"Parsing loadCSVDataOp with args $args")
 		val argParser = KeyValuePassthrough(args)
 		val path = argParser.getString("ops.path", "HDFS path to data")
-		loadCsvDataOp(path, argParser)(_)
+		val partitions = argParser.getIntOption("ops.partitions", "Number of data partitions")
+		loadCsvDataOp(path, argParser, partitions)(_)
 	}
 
 	/**

--- a/tile-generation/src/test/scala/com/oculusinfo/tilegen/pipeline/PipelineOperationsTests.scala
+++ b/tile-generation/src/test/scala/com/oculusinfo/tilegen/pipeline/PipelineOperationsTests.scala
@@ -62,7 +62,7 @@ class PipelineOperationsTests extends FunSuite with SharedSparkContext {
 		val resultList = ListBuffer[Any]()
 
 		val resPath = getClass.getResource("/json_test.data").toURI.getPath
-		val argsMap = Map("ops.path" -> resPath)
+		val argsMap = Map("ops.path" -> resPath, "ops.partitions" -> "1")
 
 		val loadStage = new PipelineStage("load", parseLoadJsonDataOp(argsMap))
 		loadStage.addChild(new PipelineStage("output", outputOps(List("val", "time"), resultList)(_)))
@@ -80,6 +80,7 @@ class PipelineOperationsTests extends FunSuite with SharedSparkContext {
 		val resPath = getClass.getResource("/csv_test.data").toURI.getPath
 		val argsMap = Map(
 			"ops.path" -> resPath,
+			"ops.partitions" -> "1",
 			"oculus.binning.parsing.separator" -> " *, *",
 			"oculus.binning.parsing.vAl.index" -> "0",
 			"oculus.binning.parsing.vAl.fieldType" -> "string", // use mixed case fieldname to test case sensitivity


### PR DESCRIPTION
CSV and JSON load ops will result in the data being partitioned according to its layout in HDFS.  A parameter has been added to both to force a repartition to a desired size.