### PR TITLE
adds scale parameter to sigmoid transform

### DIFF
--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/value/SigmoidValueTransformer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/value/SigmoidValueTransformer.java
@@ -28,25 +28,32 @@ package com.oculusinfo.tile.rendering.transformations.value;
  * A value transformer that transforms two-tailed infinite range into a finite
  * range.  The range assumes a center of zero, and min/max defined as
  * +/-(max(abs(expectedMin),abs(expectedMax)), with the extrema mapped to +/-10
- * of the sigmoid curve.
+ * of the sigmoid curve.  The curve can be further scaled int the x direction for a
+ * better data fit if needed.
  *
  * @author nkronenfeld
  */
 public class SigmoidValueTransformer implements ValueTransformer<Double> {
+	private double _distance;
 	private double _scale;
 
-    public SigmoidValueTransformer (double expectedMin, double expectedMax) {
-        _scale = Math.max(Math.abs(expectedMin), Math.abs(expectedMax));
-    }
+	public SigmoidValueTransformer (double expectedMin, double expectedMax) {
+		this(expectedMin, expectedMax, 1d);
+	}
 
-    @Override
-    public Double transform (Double value) {
-		double scaledInput = value / _scale * 10.0;
+	public SigmoidValueTransformer (double expectedMin, double expectedMax, double scale) {
+		_scale = scale * 10d;
+		_distance = Math.max(Math.abs(expectedMin), Math.abs(expectedMax));
+	}
+
+	@Override
+	public Double transform (Double value) {
+		double scaledInput = value / _distance * _scale;
 		return (1/(1+Math.exp(-scaledInput)));
-    }
+	}
 
-    @Override
-    public Double getMaximumValue () {
-        return 1.0;
-    }
+	@Override
+	public Double getMaximumValue () {
+		return 1.0;
+	}
 }

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/value/ValueTransformerFactory.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/value/ValueTransformerFactory.java
@@ -33,7 +33,7 @@ import java.util.List;
 
 /**
  * A factory for creating {@link ValueTransformer} objects.
- * 
+ *
  * @author cregnier
  *
  */
@@ -60,6 +60,10 @@ public class ValueTransformerFactory extends ConfigurableFactory<ValueTransforme
 			"The minimum value used for the log transform when the input data minimum is <= 0",
 			1);
 
+	public static final DoubleProperty TRANSFORM_SCALE = new DoubleProperty("scale",
+		"A scaling factor to apply to a transform",
+		1.0);
+
 
 
 	// One cannot produce a Class<ValueTransformer<?>> directly, one can only use erasure to fake it.
@@ -82,6 +86,7 @@ public class ValueTransformerFactory extends ConfigurableFactory<ValueTransforme
 		addProperty(LAYER_MAXIMUM);
 		addProperty(LAYER_MINIMUM);
 		addProperty(LOG_MINIMUM);
+		addProperty(TRANSFORM_SCALE);
 	}
 
 	private double _layerMaximum;
@@ -130,9 +135,13 @@ public class ValueTransformerFactory extends ConfigurableFactory<ValueTransforme
 
 			return new LinearValueTransformer(min, max);
 		} else if ("half-sigmoid".equals(name)) {
-		    return new HalfSigmoidValueTransformer(layerMin, layerMax);
+			return new HalfSigmoidValueTransformer(layerMin, layerMax);
 		} else if ("sigmoid".equals(name)) {
-            return new SigmoidValueTransformer(layerMin, layerMax);
+			if (hasPropertyValue(TRANSFORM_SCALE)) {
+				return new SigmoidValueTransformer(layerMin, layerMax, getPropertyValue(TRANSFORM_SCALE));
+			} else {
+				return new SigmoidValueTransformer(layerMin, layerMax);
+			}
 		} else {
 			// Linear is default, even if passed an unknown type.
 			return new LinearValueTransformer(layerMin, layerMax);


### PR DESCRIPTION
New "scale" parameter is now supported by the transform factory, used by sigmoid transform to scale the curve in the x direction.  Allows for better visual separation when dealing with long tail data sets.
