### PR TITLE
Bug fixes for hierarhical tile gen (ie for graph tiling)

### DIFF
--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/datasets/TilingTaskParameters.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/datasets/TilingTaskParameters.scala
@@ -97,7 +97,7 @@ class TilingTaskParametersFactory (parent: ConfigurableFactory[_], path: JavaLis
 					else Range(extrema(0).trim.toInt, extrema(1).trim.toInt+1).toSeq
 				}
 			).fold(Seq[Int]())(_ ++ _)
-		)
+		).filter(levelSeq => levelSeq != Seq[Int]())	// discard empty entries
 	}
 
 	override protected def create(): TilingTaskParameters = {

--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/examples/apps/CSVGraphBinner.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/examples/apps/CSVGraphBinner.scala
@@ -424,8 +424,8 @@ object CSVGraphBinner {
 					val source = new CSVDataSource(wrappedProps)
 					// Read the CSV into a schema file
 					val reader = new CSVReader(sqlc, source.getData(sc), wrappedProps)
-					// Register it as a table
-					val table = "table"+argIdx
+					// Register it as a table (include hierarchy level in table name too)
+					val table = "table"+argIdx+m
 					reader.asSchemaRDD.registerTempTable(table)
 
 					val cache = wrappedProps.getBoolean(
@@ -437,6 +437,8 @@ object CSVGraphBinner {
 					// perform tile generation
 					processTaskGeneric(sc, TilingTask(sqlc, table, props), tileIO)
 
+					if (cache) sqlc.uncacheTable(table)
+					
 					// reset tile gen levels for next loop iteration
 					props.setProperty("oculus.binning.levels."+m, "")
 				}


### PR DESCRIPTION
Bug fixes for hierarhical tile gen (ie for graph tiling):
- uncaching SparkSQL tables after each hierachy has been tiled.
- error checking in tilingTaskParameters: discards any empty zoom level sets (was causing an exception during hierarchical tile gen)