### PR TITLE
Build fails due to reslet maven repo location change

### DIFF
--- a/annotation-service/build.gradle
+++ b/annotation-service/build.gradle
@@ -3,14 +3,6 @@ description = "Back-end service for tile annotations"
 // Pulls in required plugins
 apply plugin: "java"
 
-// Restlet isn't in maven central for some reason, so we need to add their
-// location to the set from the parent build file.
-repositories {
-	maven {
-		url = "http://maven.restlet.org"
-	}
-}
-
 // Jars / projects this project depends on.
 dependencies {
 	compile "org.restlet.jee:org.restlet:2.1.2"

--- a/build.gradle
+++ b/build.gradle
@@ -137,7 +137,7 @@ subprojects {
 		}
 		// Needed for our org.restlet dependencies
 		maven {
-			url "https://repository.sonatype.org/content/groups/forge"
+			url = "https://maven.restlet.com/"
 		}
 	}
 

--- a/tile-service/build.gradle
+++ b/tile-service/build.gradle
@@ -3,14 +3,6 @@ description = "Useful utilites to help pyramid-based binning schemes (and others
 // Pulls in the Java plugin
 apply plugin: "java"
 
-// Restlet isn't in maven central for some reason, so we need to add their
-// location to the set from the parent build file.
-repositories {
-	maven {
-		url = "http://maven.restlet.org"
-	}
-}
-
 // Jars / projects this project depends on.
 dependencies {
 	compile "org.restlet.jee:org.restlet:2.1.2"


### PR DESCRIPTION
Fixes #219. http://maven.restlet.org changed to: https://maven.restlet.com/