### PR TITLE
adds date filter that works with timsetamp column value

### DIFF
--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/pipeline/PipelineOperationsParsing.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/pipeline/PipelineOperationsParsing.scala
@@ -26,8 +26,6 @@
  */
 package com.oculusinfo.tilegen.pipeline
 
-import java.util.concurrent.atomic.AtomicInteger
-
 import com.oculusinfo.binning.util.JsonUtilities
 import com.oculusinfo.tilegen.datasets.{TilingTaskParameters, TilingTaskParametersFactory}
 import com.oculusinfo.tilegen.pipeline.PipelineOperations._
@@ -132,7 +130,7 @@ object PipelineOperationsParsing extends Logging {
 
 	/**
 	 * Parses args for a filter to the valid range of a mercator geographic projection.
-	 * 
+	 *
 	 * Arguments:
 	 *  ops.latitude - the column containing the latitude value
 	 */


### PR DESCRIPTION
Date-based columns are now represented as java.sql.Timestamp values internally, so a date filter op needed to be added that could work off of that type.