### PR TITLE
Allows column names that need escaping

### DIFF
--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/datasets/TilingTask.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/datasets/TilingTask.scala
@@ -277,7 +277,7 @@ abstract class TilingTask[PT: ClassTag, DT: ClassTag, AT: ClassTag, BT]
 
 	private def getAxisBounds(): (Double, Double, Double, Double) = {
 		val selectStmt =
-			indexer.fields.flatMap(field => List("min(" + field + ")", "max(" + field + ")"))
+			indexer.fields.flatMap(field => List("min(`" + field + "`)", "max(`" + field + "`)"))
 				.mkString("SELECT ", ", ", " FROM " + table)
 		val bounds = sqlc.sql(selectStmt).take(1)(0)
 		val fields = indexer.fields.size
@@ -360,7 +360,7 @@ class StaticTilingTask[PT: ClassTag, DT: ClassTag, AT: ClassTag, BT]
 			val allFields = indexer.fields ++ valuer.fields ++ dataAnalyticFields
 
 			val selectStmt =
-				allFields.mkString("SELECT ", ", ", " FROM "+table)
+				allFields.mkString("SELECT `", "`, `", "` FROM "+table)
 
 			val data = sqlc.sql(selectStmt)
 


### PR DESCRIPTION
Surrounds column name references in TilingTask with ` to permit columns named _c1, etc.

There may be other places in the code that need the same fix.

Also, this PR is against the spark-1.3.0 branch (our project is pinned to that branch for now and we need this fix against this branch). Feel free to rebase against develop.