### PR TITLE
Creating OperatorBucketTileTransformer to replace the AverageFilterBy…

### DIFF
--- a/binning-utilities/src/main/java/com/oculusinfo/binning/impl/AverageTileBucketView.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/impl/AverageTileBucketView.java
@@ -30,61 +30,28 @@ import java.util.List;
 
 import com.oculusinfo.binning.TileData;
 import com.oculusinfo.binning.TileIndex;
-import com.oculusinfo.binning.util.Operator;
+
 
 
 
 /**
  * This implementation of TileData takes a TileData whose bins are lists of buckets and presents
- *  a view to a range of buckets that are compared to an average of another defined range of buckets.
- *  The caller can specify what operation to use for the comparison.
+ *  a view to the average value of a range of buckets
  *
  */
-public class AverageTileBucketView<T> implements TileData<List<T>> {
+public class AverageTileBucketView<T> implements TileData<T> {
 	private static final long serialVersionUID = 1234567890L;
 
 	private TileData<List<T>> _base 		= null;
-	private Number[][] 		  _averageBins  = null;
-	private Operator		  _operator 	= null;
+
 	private Integer			  _startCompare = 0;
 	private Integer			  _endCompare 	= 0;
 
 
-	public AverageTileBucketView (TileData<List<T>> base, int startAv, int endAv, String op, int startComp, int endComp) {
+	public AverageTileBucketView (TileData<List<T>> base, int startComp, int endComp) {
 		_base = base;
-		_operator = new Operator(op);
 		_startCompare = startComp;
 		_endCompare = endComp;
-		_averageBins = new Number[getDefinition().getXBins()][getDefinition().getYBins()];
-
-		if ( startAv < 0 || startAv > endAv ){
-			throw new IllegalArgumentException("Constructor for AverageTileBucketView: arguments are invalid.  start average bucket: " + startAv + ", end time bucket: " + endAv);
-		}
-
-		// compute bin averages for selected average range
-		for ( int tx = 0; tx < getDefinition().getXBins(); tx++ ) {
-			for ( int ty = 0; ty < getDefinition().getYBins(); ty++ ) {
-				List<T> binContents = _base.getBin(tx, ty);
-				int binSize = binContents.size();
-				int end = ( endAv < binSize ) ? endAv : binSize;
-
-				double total = 0;
-				int count = 0;
-				for(int i = 0; i < binSize; i++) {
-					if ( i >= startAv && i <= end ) {
-						Number value = (Number) binContents.get(i);
-						total = total + value.doubleValue();
-						count++;
-					}
-				}
-				if ( count == 0 ) {
-					// if the count is 0, no values found in the bin
-					_averageBins[tx][ty] = 0.0;
-				} else {
-					_averageBins[tx][ty] = (total/count);
-				}
-			}
-		}
 	}
 
 
@@ -95,20 +62,20 @@ public class AverageTileBucketView<T> implements TileData<List<T>> {
 
 
 	@Override
-	public void setBin(int x, int y, List<T> value)  {
+	// method not implemented as this view is to be read only
+	public void setBin(int x, int y, T value)  {
 		if (x < 0 || x >= getDefinition().getXBins()) {
 			throw new IllegalArgumentException("Bin x index is outside of tile's valid bin range");
 		}
 		if (y < 0 || y >= getDefinition().getYBins()) {
 			throw new IllegalArgumentException("Bin y index is outside of tile's valid bin range");
 		}
-		_base.setBin( x, y, value );
 	}
 
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public List<T> getBin (int x, int y) {
+	public T getBin (int x, int y) {
 		if (x < 0 || x >= getDefinition().getXBins()) {
 			throw new IllegalArgumentException("Bin x index is outside of tile's valid bin range");
 		}
@@ -116,19 +83,26 @@ public class AverageTileBucketView<T> implements TileData<List<T>> {
 			throw new IllegalArgumentException("Bin y index is outside of tile's valid bin range");
 		}
 
+		Number result = 0.0;
+		
+		// compute bin averages for selected average range
 		List<T> binContents = _base.getBin(x, y);
 		int binSize = binContents.size();
-		int start = ( _startCompare != null ) ? _startCompare : 0;
-		int end = ( _endCompare != null && _endCompare < binSize && _endCompare != 0) ? _endCompare : binSize;
+		int end = ( _endCompare < binSize ) ? _endCompare : binSize;
 
+		double total = 0;
+		int count = 0;
 		for(int i = 0; i < binSize; i++) {
-			if ( i >= start && i <= end ) {
-				binContents.set(i, (T)_operator.Calculate( (Number)binContents.get(i), _averageBins[x][y]));
-			} else {
-				binContents.set(i, null);
+			if ( i >= _startCompare && i <= end ) {
+				Number value = (Number) binContents.get(i);
+				total = total + value.doubleValue();
+				count++;
 			}
 		}
-		return binContents;
+		if ( count != 0 ) {
+			result = (total/count);
+		}		
+		return (T) result;
 	}
 
 

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/impl/DeltaTileBucketView.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/impl/DeltaTileBucketView.java
@@ -25,7 +25,6 @@ package com.oculusinfo.binning.impl;
 
 
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/impl/OperationTileBucketView.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/impl/OperationTileBucketView.java
@@ -44,19 +44,19 @@ import com.oculusinfo.binning.util.Operator;
 public class OperationTileBucketView<T> implements TileData<List<T>> {
 	private static final long serialVersionUID = 1234567890L;
 
-	private TileData<T> _opTileA 	= null;
-	private TileData<T> _opTileB 	= null;
-	private Operator 	_op 		= null;
+	private TileData<T> _opTileAverage 	= null;
+	private TileData<T> _opTileCompare 	= null;
+	private Operator 	_op 			= null;
 
 
-	public OperationTileBucketView (TileData<T> opTileA, TileData<T> opTileB, String op) {
-		_opTileA = opTileA;
-		_opTileB = opTileB;
+	public OperationTileBucketView (TileData<T> opTileAverage, TileData<T> opTileCompare, String op) {
+		_opTileAverage = opTileAverage;
+		_opTileCompare = opTileCompare;
 
 		_op = new Operator(op);
 		
-		if (   getDefinition().getXBins() != _opTileB.getDefinition().getXBins()
-			|| getDefinition().getYBins() != _opTileB.getDefinition().getYBins()) {
+		if (   getDefinition().getXBins() != _opTileAverage.getDefinition().getXBins()
+			|| getDefinition().getYBins() != _opTileAverage.getDefinition().getYBins()) {
 			throw new IllegalArgumentException("Constructor for OperationTileBucketView: arguments are invalid. Tiles to compare are incompatible");
 		}
 	}
@@ -64,7 +64,7 @@ public class OperationTileBucketView<T> implements TileData<List<T>> {
 
 	@Override
 	public TileIndex getDefinition () {
-		return _opTileA.getDefinition();
+		return _opTileCompare.getDefinition();
 	}
 
 
@@ -90,26 +90,26 @@ public class OperationTileBucketView<T> implements TileData<List<T>> {
 			throw new IllegalArgumentException("Bin y index is outside of tile's valid bin range");
 		}
 		List<T> result = new ArrayList<>();
-		result.add( (T)_op.Calculate( (Number)_opTileA.getBin(x, y), (Number)_opTileB.getBin(x, y) ) );
+		result.add( (T)_op.Calculate( (Number)_opTileCompare.getBin(x, y), (Number)_opTileAverage.getBin(x, y) ) );
 		return result;
 	}
 
 
 	@Override
 	public Collection<String> getMetaDataProperties () {
-		return _opTileA.getMetaDataProperties();
+		return _opTileCompare.getMetaDataProperties();
 	}
 
 
 	@Override
 	public String getMetaData (String property) {
-		return _opTileA.getMetaData(property);
+		return _opTileCompare.getMetaData(property);
 	}
 
 
 	@Override
 	public void setMetaData (String property, Object value) {
-		_opTileA.setMetaData(property, value);
+		_opTileCompare.setMetaData(property, value);
 	}
 
 }

--- a/binning-utilities/src/test/java/com/oculusinfo/binning/impl/TileDataViewTests.java
+++ b/binning-utilities/src/test/java/com/oculusinfo/binning/impl/TileDataViewTests.java
@@ -185,4 +185,33 @@ public class TileDataViewTests {
 			}
 		}
 	}
+	
+	@Test
+	public void testOperationTileBucketView () {
+		int startA = 0, endA = 1;
+		int startB = 0, endB = 3;
+		// since we modify the tile, we won't use a static class tile
+		TileData<List<Double>> sourceListTile = new DenseTileData<>(new TileIndex(1, 1, 1, 2, 2),
+															            Arrays.asList(Arrays.asList( 2.0, 2.0,  4.0,  4.0),
+															            			  Arrays.asList( 4.0, 4.0,  8.0,  8.0),
+															            			  Arrays.asList( 6.0, 6.0, 12.0, 12.0),
+															            			  Arrays.asList( 8.0, 8.0, 16.0, 16.0)));
+		AverageTileBucketView<Double> averageTile = new AverageTileBucketView<Double>(sourceListTile, startA, endA);
+		AverageTileBucketView<Double> compareTile = new AverageTileBucketView<Double>(sourceListTile, startB, endB);
+		OperationTileBucketView<Double> underTest = new OperationTileBucketView<Double>(averageTile, compareTile, "//");
+		
+		Assert.assertEquals(1, underTest.getDefinition().getLevel());
+		Assert.assertEquals(1, underTest.getDefinition().getX());
+		Assert.assertEquals(1, underTest.getDefinition().getY());
+		Assert.assertEquals(2, underTest.getDefinition().getXBins());
+		Assert.assertEquals(2, underTest.getDefinition().getYBins());
+		
+		for (int y=0; y<underTest.getDefinition().getYBins(); y++) {
+			for (int x=0; x<underTest.getDefinition().getXBins(); x++) {
+				List<Double> bin = underTest.getBin(x,y);
+				Double binValue = bin.get(0);
+				Assert.assertEquals( 1.5, binValue, 0.01); 
+			}
+		}
+	}
 }

--- a/binning-utilities/src/test/java/com/oculusinfo/binning/impl/TileDataViewTests.java
+++ b/binning-utilities/src/test/java/com/oculusinfo/binning/impl/TileDataViewTests.java
@@ -104,11 +104,11 @@ public class TileDataViewTests {
 	public void testAverageTileBucketView () {
 		// since we modify the tile, we won't use a static class tile
 		TileData<List<Double>> sourceListTile = new DenseTileData<>(new TileIndex(1, 1, 1, 2, 2),
-															            Arrays.asList(Arrays.asList( 1.0,  2.0,  3.0,  4.0),
-															            			  Arrays.asList( 5.0,  6.0,  7.0,  8.0),
-															            			  Arrays.asList( 9.0, 10.0, 11.0, 12.0),
-															            			  Arrays.asList(13.0, 14.0, 15.0, 16.0)));
-		AverageTileBucketView<Double> underTest = new AverageTileBucketView<Double>(sourceListTile, 0, 3, "-", 1, 2);
+															            Arrays.asList(Arrays.asList( 1.0, 2.0, 3.0, 4.0),
+															            			  Arrays.asList( 2.0, 3.0, 4.0, 1.0),
+															            			  Arrays.asList( 3.0, 4.0, 1.0, 2.0),
+															            			  Arrays.asList( 4.0, 3.0, 2.0, 1.0)));
+		AverageTileBucketView<Double> underTest = new AverageTileBucketView<Double>(sourceListTile, 0, 3);
 		
 		Assert.assertEquals(1, underTest.getDefinition().getLevel());
 		Assert.assertEquals(1, underTest.getDefinition().getX());
@@ -118,12 +118,7 @@ public class TileDataViewTests {
 		
 		for (int y=0; y<underTest.getDefinition().getYBins(); y++) {
 			for (int x=0; x<underTest.getDefinition().getXBins(); x++) {
-				List<Double> bin = underTest.getBin(x,y);
-				
-				Assert.assertNull( bin.get(0) ); 				// buckets should be filtered out
-				Assert.assertNull( bin.get(3) ); 				// buckets should be filtered out
-				Assert.assertEquals(-0.5, bin.get(1), 0.01); 	// value '-' average
-				Assert.assertEquals( 0.5, bin.get(2), 0.01); 	// value '-' average 
+				Assert.assertEquals(2.5, underTest.getBin(x,y).doubleValue(), 0.01); 	// value '-' average
 			}
 		}
 	}

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/TileTransformerFactory.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/TileTransformerFactory.java
@@ -86,9 +86,9 @@ public class TileTransformerFactory extends ConfigurableFactory<TileTransformer<
 		} else if ("filtertopicbucket".equals(transformerTypes)) {
 			JSONObject arguments = getPropertyValue(INITIALIZATION_DATA);
 			return new FilterTopicByBucketTileTransformer<>(arguments);
-		} else if ("averagefilterbucket".equals(transformerTypes)) {
+		} else if ("operatorbucket".equals(transformerTypes)) {
 			JSONObject arguments = getPropertyValue(INITIALIZATION_DATA);
-			return new AverageFilterByBucketTileTransformer<>(arguments);
+			return new OperatorBucketTileTransformer<>(arguments);
 		} else {  // 'identity' or none passed in will give the default transformer
 			return new IdentityTileTransformer<Object>();
 		}


### PR DESCRIPTION
…BucketTileTransformer and updated behaviour of AverageTileBucketView and added OperationTileBucketView to better align with the requirements of this feature.  The AverageTileBucketView will now return a single value representing the average of all buckets in the bin requested.  The OperationTileBucketView will take two of these AverageTileBucketViews and perform an operation of the averages passed back from getBin and returns this single value.  This way we can compute a moving average to give more contextual data to the user comparing values in the time facets.