### PR TITLE
Fixing issue with the bucket views when client makes request without …

### DIFF
--- a/binning-utilities/src/main/java/com/oculusinfo/binning/impl/AverageTileBucketView.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/impl/AverageTileBucketView.java
@@ -44,8 +44,8 @@ public class AverageTileBucketView<T> implements TileData<T> {
 
 	private TileData<List<T>> _base 		= null;
 
-	private Integer			  _startCompare = 0;
-	private Integer			  _endCompare 	= 0;
+	private Integer			  _startCompare = null;
+	private Integer			  _endCompare 	= null;
 
 
 	public AverageTileBucketView (TileData<List<T>> base, int startComp, int endComp) {
@@ -88,12 +88,13 @@ public class AverageTileBucketView<T> implements TileData<T> {
 		// compute bin averages for selected average range
 		List<T> binContents = _base.getBin(x, y);
 		int binSize = binContents.size();
-		int end = ( _endCompare < binSize ) ? _endCompare : binSize;
+		int start = ( _startCompare != null ) ? _startCompare : 0;
+		int end = ( _endCompare != null && _endCompare < binSize && _endCompare != 0) ? _endCompare : binSize;
 
 		double total = 0;
 		int count = 0;
 		for(int i = 0; i < binSize; i++) {
-			if ( i >= _startCompare && i <= end ) {
+			if ( i >= start && i <= end ) {
 				Number value = (Number) binContents.get(i);
 				total = total + value.doubleValue();
 				count++;

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/impl/DeltaTileBucketView.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/impl/DeltaTileBucketView.java
@@ -45,8 +45,8 @@ public class DeltaTileBucketView<T> implements TileData<List<T>> {
 	private TileData<List<T>> _base 		= null;
 	private TileData<List<T>> _delta		= null;
 	private Operator		  _operator 	= null;
-	private Integer			  _startCompare = 0;
-	private Integer			  _endCompare 	= 0;
+	private Integer			  _startCompare = null;
+	private Integer			  _endCompare 	= null;
 
 
 	public DeltaTileBucketView (TileData<List<T>> base, TileData<List<T>> delta, String op, int startComp, int endComp) {

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/impl/FilterTileBucketView.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/impl/FilterTileBucketView.java
@@ -42,8 +42,8 @@ public class FilterTileBucketView<T> implements TileData<List<T>> {
 	private static final long serialVersionUID = 1234567890L;
 
 	private TileData<List<T>> _base 		= null;
-	private Integer			  _startBucket 	= 0;
-	private Integer			  _endBucket 	= 0;
+	private Integer			  _startBucket 	= null;
+	private Integer			  _endBucket 	= null;
 
 
 	public FilterTileBucketView (TileData<List<T>> base, int startBucket, int endBucket) {
@@ -83,7 +83,7 @@ public class FilterTileBucketView<T> implements TileData<List<T>> {
 		if (y < 0 || y >= getDefinition().getYBins()) {
 			throw new IllegalArgumentException("Bin y index is outside of tile's valid bin range");
 		}
-		//List<T> newBin = new ArrayList<>();
+
 		List<T> binContents = _base.getBin(x, y);
 		int binSize = binContents.size();
 		int start = ( _startBucket != null ) ? _startBucket : 0;


### PR DESCRIPTION
…passing in parameter data.  Client expects entire data range to be shown when view is initialized without any parameters.