### PR TITLE
Colour ramps for delta plots

### DIFF
--- a/binning-utilities/src/main/java/com/oculusinfo/binning/impl/AverageTileBucketView.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/impl/AverageTileBucketView.java
@@ -25,6 +25,7 @@ package com.oculusinfo.binning.impl;
 
 
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
@@ -39,7 +40,7 @@ import com.oculusinfo.binning.TileIndex;
  *  a view to the average value of a range of buckets
  *
  */
-public class AverageTileBucketView<T> implements TileData<T> {
+public class AverageTileBucketView<T extends Number> implements TileData<List<T>> {
 	private static final long serialVersionUID = 1234567890L;
 
 	private TileData<List<T>> _base 		= null;
@@ -54,7 +55,6 @@ public class AverageTileBucketView<T> implements TileData<T> {
 		_endCompare = endComp;
 	}
 
-
 	@Override
 	public TileIndex getDefinition () {
 		return _base.getDefinition();
@@ -63,28 +63,14 @@ public class AverageTileBucketView<T> implements TileData<T> {
 
 	@Override
 	// method not implemented as this view is to be read only
-	public void setBin(int x, int y, T value)  {
-		if (x < 0 || x >= getDefinition().getXBins()) {
-			throw new IllegalArgumentException("Bin x index is outside of tile's valid bin range");
-		}
-		if (y < 0 || y >= getDefinition().getYBins()) {
-			throw new IllegalArgumentException("Bin y index is outside of tile's valid bin range");
-		}
-	}
+	public void setBin(int x, int y, List<T> value)  {}
 
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public T getBin (int x, int y) {
-		if (x < 0 || x >= getDefinition().getXBins()) {
-			throw new IllegalArgumentException("Bin x index is outside of tile's valid bin range");
-		}
-		if (y < 0 || y >= getDefinition().getYBins()) {
-			throw new IllegalArgumentException("Bin y index is outside of tile's valid bin range");
-		}
-
+	public List<T> getBin (int x, int y) {
 		Number result = 0.0;
-		
+
 		// compute bin averages for selected average range
 		List<T> binContents = _base.getBin(x, y);
 		int binSize = binContents.size();
@@ -93,17 +79,19 @@ public class AverageTileBucketView<T> implements TileData<T> {
 
 		double total = 0;
 		int count = 0;
-		for(int i = 0; i < binSize; i++) {
+		for(int i = start; i < binSize; i++) {
 			if ( i >= start && i <= end ) {
-				Number value = (Number) binContents.get(i);
+				Number value = binContents.get(i);
 				total = total + value.doubleValue();
 				count++;
 			}
 		}
 		if ( count != 0 ) {
 			result = (total/count);
-		}		
-		return (T) result;
+		}
+		List<T> resultList = new ArrayList<>(1);
+		resultList.add((T) result);
+		return resultList;
 	}
 
 

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/impl/BinaryOperationTileView.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/impl/BinaryOperationTileView.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 import com.oculusinfo.binning.TileData;
 import com.oculusinfo.binning.TileIndex;
-import com.oculusinfo.binning.util.Operator;
+import com.oculusinfo.binning.util.BinaryOperator;
 
 
 
@@ -41,76 +41,72 @@ import com.oculusinfo.binning.util.Operator;
  *  that are compared to each other using the operator passed in as a string.
  *
  */
-public class OperationTileBucketView<T> implements TileData<List<T>> {
+public class BinaryOperationTileView<T extends Number> implements TileData<List<T>> {
 	private static final long serialVersionUID = 1234567890L;
 
-	private TileData<T> _opTileAverage 	= null;
-	private TileData<T> _opTileCompare 	= null;
-	private Operator 	_op 			= null;
+	private TileData<List<T>> _tileData1 = null;
+	private TileData<List<T>> _tileData2 = null;
+	private BinaryOperator _op 			= null;
 
+	private final int _binCount;
 
-	public OperationTileBucketView(TileData<T> opTileAverage, TileData<T> opTileCompare, String op) {
-		_opTileAverage = opTileAverage;
-		_opTileCompare = opTileCompare;
+	private final Number _errorValue;
 
-		_op = new Operator(op);
+	public BinaryOperationTileView(TileData<List<T>> tileData1, TileData<List<T>> tileData2, BinaryOperator.OPERATOR_TYPE op,
+								   Number errorValue) {
+		_errorValue = errorValue;
+		_tileData1 = tileData1;
+		_tileData2 = tileData2;
 
-		if (   getDefinition().getXBins() != _opTileAverage.getDefinition().getXBins()
-			|| getDefinition().getYBins() != _opTileAverage.getDefinition().getYBins()) {
-			throw new IllegalArgumentException("Constructor for OperationTileBucketView: arguments are invalid. Tiles to compare are incompatible");
+		_op = new BinaryOperator(op);
+
+		if (   getDefinition().getXBins() != _tileData1.getDefinition().getXBins()
+			|| getDefinition().getYBins() != _tileData1.getDefinition().getYBins()) {
+			throw new IllegalArgumentException("Constructor for BinaryOperationTileBucketView: " +
+				"arguments are invalid. Tiles to compare are incompatible");
 		}
+
+		_binCount = _tileData1.getBin(0, 0).size();
 	}
 
 
 	@Override
 	public TileIndex getDefinition () {
-		return _opTileCompare.getDefinition();
+		return _tileData2.getDefinition();
 	}
 
 
 	@Override
 	// method not implemented as this view is to be read only
-	public void setBin(int x, int y, List<T> value)  {
-		if (x < 0 || x >= getDefinition().getXBins()) {
-			throw new IllegalArgumentException("Bin x index is outside of tile's valid bin range");
-		}
-		if (y < 0 || y >= getDefinition().getYBins()) {
-			throw new IllegalArgumentException("Bin y index is outside of tile's valid bin range");
-		}
-	}
+	public void setBin(int x, int y, List<T> value)  {}
 
 
 	@SuppressWarnings("unchecked")
 	@Override
 	public List<T> getBin (int x, int y) {
-		if (x < 0 || x >= getDefinition().getXBins()) {
-			throw new IllegalArgumentException("Bin x index is outside of tile's valid bin range");
-		}
-		if (y < 0 || y >= getDefinition().getYBins()) {
-			throw new IllegalArgumentException("Bin y index is outside of tile's valid bin range");
-		}
 		List<T> result = new ArrayList<>();
-		double r = _op.Calculate( (Number)_opTileCompare.getBin(x, y), (Number)_opTileAverage.getBin(x, y)).doubleValue();
-		result.add( (T) Double.valueOf(r));
+		for (int i = 0; i < _binCount; i++) {
+			result.add((T) _op.calculate(_tileData1.getBin(x, y).get(i), _tileData2.getBin(x, y).get(i), _errorValue));
+		}
 		return result;
 	}
 
 
 	@Override
 	public Collection<String> getMetaDataProperties () {
-		return _opTileCompare.getMetaDataProperties();
+		return _tileData2.getMetaDataProperties();
 	}
 
 
 	@Override
 	public String getMetaData (String property) {
-		return _opTileCompare.getMetaData(property);
+		return _tileData2.getMetaData(property);
 	}
 
 
 	@Override
 	public void setMetaData (String property, Object value) {
-		_opTileCompare.setMetaData(property, value);
+		_tileData2.setMetaData(property, value);
 	}
 
 }

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/impl/DeltaTileBucketView.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/impl/DeltaTileBucketView.java
@@ -30,7 +30,7 @@ import java.util.List;
 
 import com.oculusinfo.binning.TileData;
 import com.oculusinfo.binning.TileIndex;
-import com.oculusinfo.binning.util.Operator;
+import com.oculusinfo.binning.util.BinaryOperator;
 
 
 
@@ -44,15 +44,16 @@ public class DeltaTileBucketView<T> implements TileData<List<T>> {
 
 	private TileData<List<T>> _base 		= null;
 	private TileData<List<T>> _delta		= null;
-	private Operator		  _operator 	= null;
+	private BinaryOperator _operator 	= null;
 	private Integer			  _startCompare = null;
 	private Integer			  _endCompare 	= null;
 
 
-	public DeltaTileBucketView (TileData<List<T>> base, TileData<List<T>> delta, String op, int startComp, int endComp) {
+	public DeltaTileBucketView (TileData<List<T>> base, TileData<List<T>> delta, BinaryOperator.OPERATOR_TYPE op,
+								int startComp, int endComp) {
 		_base = base;
 		_delta = delta;
-		_operator = new Operator(op);
+		_operator = new BinaryOperator(op);
 		_startCompare = startComp;
 		_endCompare = endComp;
 
@@ -103,7 +104,7 @@ public class DeltaTileBucketView<T> implements TileData<List<T>> {
 
 		for(int i = 0; i < binSize; i++) {
 			if ( i >= start && i <= end ) {
-				sourceData.set(i, (T)_operator.Calculate( (Number)sourceData.get(i), (Number)deltaData.get(i)));
+				sourceData.set(i, (T)_operator.calculate( (Number)sourceData.get(i), (Number)deltaData.get(i)));
 			} else {
 				sourceData.set(i, null);
 			}

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/impl/OperationTileBucketView.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/impl/OperationTileBucketView.java
@@ -49,12 +49,12 @@ public class OperationTileBucketView<T> implements TileData<List<T>> {
 	private Operator 	_op 			= null;
 
 
-	public OperationTileBucketView (TileData<T> opTileAverage, TileData<T> opTileCompare, String op) {
+	public OperationTileBucketView(TileData<T> opTileAverage, TileData<T> opTileCompare, String op) {
 		_opTileAverage = opTileAverage;
 		_opTileCompare = opTileCompare;
 
 		_op = new Operator(op);
-		
+
 		if (   getDefinition().getXBins() != _opTileAverage.getDefinition().getXBins()
 			|| getDefinition().getYBins() != _opTileAverage.getDefinition().getYBins()) {
 			throw new IllegalArgumentException("Constructor for OperationTileBucketView: arguments are invalid. Tiles to compare are incompatible");
@@ -90,7 +90,8 @@ public class OperationTileBucketView<T> implements TileData<List<T>> {
 			throw new IllegalArgumentException("Bin y index is outside of tile's valid bin range");
 		}
 		List<T> result = new ArrayList<>();
-		result.add( (T)_op.Calculate( (Number)_opTileCompare.getBin(x, y), (Number)_opTileAverage.getBin(x, y) ) );
+		double r = _op.Calculate( (Number)_opTileCompare.getBin(x, y), (Number)_opTileAverage.getBin(x, y)).doubleValue();
+		result.add( (T) Double.valueOf(r));
 		return result;
 	}
 

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/impl/UnaryOperationTileView.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/impl/UnaryOperationTileView.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2015 Uncharted Software. http://www.uncharted.software/
+ *
+ * Released under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.oculusinfo.binning.impl;
+
+import com.oculusinfo.binning.TileData;
+import com.oculusinfo.binning.TileIndex;
+import com.oculusinfo.binning.util.UnaryOperator;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class UnaryOperationTileView<T extends Number> implements TileData<List<T>> {
+
+	private final UnaryOperator _op;
+	private final Number _errorValue;
+	private final TileData<List<T>> _tileData;
+
+	public UnaryOperationTileView(UnaryOperator.OPERATOR_TYPE operation, TileData<List<T>> tileData, Number errorValue) {
+		_op = new UnaryOperator(operation);
+		_tileData = tileData;
+		_errorValue = errorValue;
+	}
+
+	@Override
+	public TileIndex getDefinition() {
+		return _tileData.getDefinition();
+	}
+
+	@Override
+	public void setBin(int x, int y, List<T> value) {}
+
+	@Override
+	public List<T> getBin(int x, int y) {
+		List<T> result = new ArrayList<>();
+		for (T d:  _tileData.getBin(x, y)) {
+			result.add((T) _op.calculate(d, _errorValue));
+		}
+		return result;
+	}
+
+	@Override
+	public Collection<String> getMetaDataProperties() {
+		return _tileData.getMetaDataProperties();
+	}
+
+	@Override
+	public String getMetaData(String property) {
+		return _tileData.getMetaData(property);
+	}
+
+	@Override
+	public void setMetaData(String property, Object value) {
+		_tileData.setMetaData(property, value);
+	}
+}

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/util/BinaryOperator.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/util/BinaryOperator.java
@@ -27,12 +27,45 @@ package com.oculusinfo.binning.util;
 /**
  * Simple abstraction of a mathematical operator that we can pass around as a parameter
  */
-public class Operator {
+public class BinaryOperator {
 
-	private String _operator = "";
+	public enum OPERATOR_TYPE {
+		ADD,
+		SUBTRACT,
+		DIVIDE,
+		MULTIPLY
+	};
 
-	public Operator(String operator) {
+	public final OPERATOR_TYPE _operator;
+
+	public BinaryOperator(OPERATOR_TYPE operator) {
 		_operator = operator;
+	}
+
+	/**
+	 * Uses the class member operator to perform the calculation.  More operations can
+	 * be added here as needed.
+	 *
+	 * @param operand1 the first value to use in the calculation
+	 * @param operand2 the second value to use in the calculation
+	 * @param errorVal optional error value to use when bad input detected
+	 * @return Number represents the result of the calculation
+	 */
+	public Number calculate(Number operand1, Number operand2, Number errorVal) {
+		if (_operator.equals(OPERATOR_TYPE.ADD)) {
+			return operand1.doubleValue() + operand2.doubleValue();
+		} else if (_operator.equals(OPERATOR_TYPE.SUBTRACT)) {
+			return operand1.doubleValue() - operand2.doubleValue();
+		} else if (_operator.equals(OPERATOR_TYPE.MULTIPLY)) {
+			return operand1.doubleValue() * operand2.doubleValue();
+		} else if (_operator.equals(OPERATOR_TYPE.DIVIDE)) {
+			if (operand2.doubleValue() == 0.0 && errorVal != null) {
+				return errorVal;
+			}
+			return operand1.doubleValue() / operand2.doubleValue();
+		} else {
+			throw new ExceptionInInitializerError();
+		}
 	}
 
 	/**
@@ -43,21 +76,7 @@ public class Operator {
 	 * @param operand2 the second value to use in the calculation
 	 * @return Number represents the result of the calculation
 	 */
-	public Number Calculate(Number operand1, Number operand2) {
-		if (_operator.equals("+")) {
-			return operand1.doubleValue() + operand2.doubleValue();
-		} else if (_operator.equals("-")) {
-			return operand1.doubleValue() - operand2.doubleValue();
-		} else if (_operator.equals("*")) {
-			return operand1.doubleValue() * operand2.doubleValue();
-		} else if (_operator.equals("//")) {
-			if (operand2.equals(0.0)) {
-				return 0.0;
-			} else {
-				return operand1.doubleValue() / operand2.doubleValue();
-			}
-		} else {
-			throw new ExceptionInInitializerError();
-		}
+	public Number calculate(Number operand1, Number operand2) {
+		return calculate(operand1, operand2, null);
 	}
 }

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/util/UnaryOperator.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/util/UnaryOperator.java
@@ -55,6 +55,9 @@ public class UnaryOperator {
 				}
 				return Math.log10(operand.doubleValue());
 			case LOG_2:
+				if (errorValue != null & operand.doubleValue() <= 0.0) {
+					return errorValue;
+				}
 				return Math.log(operand.doubleValue()) / Math.log(2);
 			default:
 				return operand;

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/util/UnaryOperator.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/util/UnaryOperator.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2015 Uncharted Software. http://www.uncharted.software/
+ *
+ * Released under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.oculusinfo.binning.util;
+
+/**
+ * A simple class to implement a unary operation.  Extend as necessary.
+ */
+public class UnaryOperator {
+	public enum OPERATOR_TYPE {
+		LOG_10,
+		LOG_2
+	}
+
+	public final OPERATOR_TYPE _operator;
+
+	/**
+	 * Create a unary operation
+	 */
+	public UnaryOperator(OPERATOR_TYPE operator) {
+		_operator = operator;
+	}
+
+	/**
+	 * Apply the unary operation.
+	 * @param operand The unary operand.
+	 * @param errorValue A value to return when an error condition ie. log10(0) is encountered.
+	 * @return The calculated value or the error value.
+	 */
+	public Number calculate(Number operand, Number errorValue) {
+		switch (_operator) {
+			case LOG_10:
+				if (errorValue != null & operand.doubleValue() <= 0.0) {
+					return errorValue;
+				}
+				return Math.log10(operand.doubleValue());
+			case LOG_2:
+				return Math.log(operand.doubleValue()) / Math.log(2);
+			default:
+				return operand;
+		}
+	}
+
+	/**
+	 * Apply the unary operation.
+	 * @param operand The unary operand.
+	 * @return The calculated value or the error value.
+	 */
+	public Number calculate(Number operand) {
+		return calculate(operand, null);
+	}
+}

--- a/binning-utilities/src/test/java/com/oculusinfo/binning/impl/TileDataViewTests.java
+++ b/binning-utilities/src/test/java/com/oculusinfo/binning/impl/TileDataViewTests.java
@@ -28,10 +28,6 @@ package com.oculusinfo.binning.impl;
 
 import com.oculusinfo.binning.TileData;
 import com.oculusinfo.binning.TileIndex;
-import com.oculusinfo.binning.impl.DenseTileData;
-import com.oculusinfo.binning.impl.SubTileDataView;
-import com.oculusinfo.binning.impl.AverageTileBucketView;
-import com.oculusinfo.binning.impl.DeltaTileBucketView;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -109,20 +105,20 @@ public class TileDataViewTests {
 															            			  Arrays.asList( 3.0, 4.0, 1.0, 2.0),
 															            			  Arrays.asList( 4.0, 3.0, 2.0, 1.0)));
 		AverageTileBucketView<Double> underTest = new AverageTileBucketView<Double>(sourceListTile, 0, 3);
-		
+
 		Assert.assertEquals(1, underTest.getDefinition().getLevel());
 		Assert.assertEquals(1, underTest.getDefinition().getX());
 		Assert.assertEquals(1, underTest.getDefinition().getY());
 		Assert.assertEquals(2, underTest.getDefinition().getXBins());
 		Assert.assertEquals(2, underTest.getDefinition().getYBins());
-		
+
 		for (int y=0; y<underTest.getDefinition().getYBins(); y++) {
 			for (int x=0; x<underTest.getDefinition().getXBins(); x++) {
 				Assert.assertEquals(2.5, underTest.getBin(x,y).doubleValue(), 0.01); 	// value '-' average
 			}
 		}
 	}
-	
+
 	@Test
 	public void testDeltaTileBucketView () {
 		int start = 1, end = 2;
@@ -133,19 +129,19 @@ public class TileDataViewTests {
 															            			  Arrays.asList( 9.0, 10.0, 11.0, 12.0),
 															            			  Arrays.asList(13.0, 14.0, 15.0, 16.0)));
 		DeltaTileBucketView<Double> underTest = new DeltaTileBucketView<Double>(sourceListTile, deltaListTile, "-", start, end);
-		
+
 		Assert.assertEquals(1, underTest.getDefinition().getLevel());
 		Assert.assertEquals(1, underTest.getDefinition().getX());
 		Assert.assertEquals(1, underTest.getDefinition().getY());
 		Assert.assertEquals(2, underTest.getDefinition().getXBins());
 		Assert.assertEquals(2, underTest.getDefinition().getYBins());
-		
+
 		for (int y=0; y<underTest.getDefinition().getYBins(); y++) {
 			for (int x=0; x<underTest.getDefinition().getXBins(); x++) {
 				List<Double> bin = underTest.getBin(x,y);
 				for (int i=0; i<bin.size(); i++) {
 					if ( i >= start && i <= end ) {
-						Assert.assertEquals( 1.0, bin.get(i), 0.01); 	// value '-' delta 
+						Assert.assertEquals( 1.0, bin.get(i), 0.01); 	// value '-' delta
 					} else {
 						Assert.assertNull(bin.get(i));
 					}
@@ -153,7 +149,7 @@ public class TileDataViewTests {
 			}
 		}
 	}
-	
+
 	@Test
 	public void testFilterTileBucketView () {
 		int start = 1, end = 2;
@@ -164,13 +160,13 @@ public class TileDataViewTests {
 															            			  Arrays.asList( 9.0, 10.0, 11.0, 12.0),
 															            			  Arrays.asList(13.0, 14.0, 15.0, 16.0)));
 		FilterTileBucketView<Double> underTest = new FilterTileBucketView<Double>(sourceListTile,start, end);
-		
+
 		Assert.assertEquals(1, underTest.getDefinition().getLevel());
 		Assert.assertEquals(1, underTest.getDefinition().getX());
 		Assert.assertEquals(1, underTest.getDefinition().getY());
 		Assert.assertEquals(2, underTest.getDefinition().getXBins());
 		Assert.assertEquals(2, underTest.getDefinition().getYBins());
-		
+
 		for (int y=0; y<underTest.getDefinition().getYBins(); y++) {
 			for (int x=0; x<underTest.getDefinition().getXBins(); x++) {
 				List<Double> bin = underTest.getBin(x,y);
@@ -185,7 +181,7 @@ public class TileDataViewTests {
 			}
 		}
 	}
-	
+
 	@Test
 	public void testOperationTileBucketView () {
 		int startA = 0, endA = 1;
@@ -199,18 +195,18 @@ public class TileDataViewTests {
 		AverageTileBucketView<Double> averageTile = new AverageTileBucketView<Double>(sourceListTile, startA, endA);
 		AverageTileBucketView<Double> compareTile = new AverageTileBucketView<Double>(sourceListTile, startB, endB);
 		OperationTileBucketView<Double> underTest = new OperationTileBucketView<Double>(averageTile, compareTile, "//");
-		
+
 		Assert.assertEquals(1, underTest.getDefinition().getLevel());
 		Assert.assertEquals(1, underTest.getDefinition().getX());
 		Assert.assertEquals(1, underTest.getDefinition().getY());
 		Assert.assertEquals(2, underTest.getDefinition().getXBins());
 		Assert.assertEquals(2, underTest.getDefinition().getYBins());
-		
+
 		for (int y=0; y<underTest.getDefinition().getYBins(); y++) {
 			for (int x=0; x<underTest.getDefinition().getXBins(); x++) {
 				List<Double> bin = underTest.getBin(x,y);
 				Double binValue = bin.get(0);
-				Assert.assertEquals( 1.5, binValue, 0.01); 
+				Assert.assertEquals( 1.5, binValue, 0.01);
 			}
 		}
 	}

--- a/binning-utilities/src/test/java/com/oculusinfo/binning/impl/TileDataViewTests.java
+++ b/binning-utilities/src/test/java/com/oculusinfo/binning/impl/TileDataViewTests.java
@@ -29,6 +29,7 @@ package com.oculusinfo.binning.impl;
 import com.oculusinfo.binning.TileData;
 import com.oculusinfo.binning.TileIndex;
 
+import com.oculusinfo.binning.util.BinaryOperator;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -114,7 +115,7 @@ public class TileDataViewTests {
 
 		for (int y=0; y<underTest.getDefinition().getYBins(); y++) {
 			for (int x=0; x<underTest.getDefinition().getXBins(); x++) {
-				Assert.assertEquals(2.5, underTest.getBin(x,y).doubleValue(), 0.01); 	// value '-' average
+				Assert.assertEquals(2.5, underTest.getBin(x,y).get(0).doubleValue(), 0.01); 	// value '-' average
 			}
 		}
 	}
@@ -128,7 +129,8 @@ public class TileDataViewTests {
 															            			  Arrays.asList( 5.0,  6.0,  7.0,  8.0),
 															            			  Arrays.asList( 9.0, 10.0, 11.0, 12.0),
 															            			  Arrays.asList(13.0, 14.0, 15.0, 16.0)));
-		DeltaTileBucketView<Double> underTest = new DeltaTileBucketView<Double>(sourceListTile, deltaListTile, "-", start, end);
+		DeltaTileBucketView<Double> underTest = new DeltaTileBucketView<>(
+			sourceListTile, deltaListTile, BinaryOperator.OPERATOR_TYPE.SUBTRACT, start, end);
 
 		Assert.assertEquals(1, underTest.getDefinition().getLevel());
 		Assert.assertEquals(1, underTest.getDefinition().getX());
@@ -194,7 +196,8 @@ public class TileDataViewTests {
 															            			  Arrays.asList( 8.0, 8.0, 16.0, 16.0)));
 		AverageTileBucketView<Double> averageTile = new AverageTileBucketView<Double>(sourceListTile, startA, endA);
 		AverageTileBucketView<Double> compareTile = new AverageTileBucketView<Double>(sourceListTile, startB, endB);
-		OperationTileBucketView<Double> underTest = new OperationTileBucketView<Double>(averageTile, compareTile, "//");
+		BinaryOperationTileView<Double> underTest =
+			new BinaryOperationTileView<Double>(averageTile, compareTile, BinaryOperator.OPERATOR_TYPE.DIVIDE, 1.0);
 
 		Assert.assertEquals(1, underTest.getDefinition().getLevel());
 		Assert.assertEquals(1, underTest.getDefinition().getX());

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/LayerConfiguration.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/LayerConfiguration.java
@@ -208,9 +208,9 @@ public class LayerConfiguration extends ConfigurableFactory<LayerConfiguration> 
 		_levelMaximum = levelMaximum;
 		_levelMinimum = levelMinimum;
 		try {
-			TileDataImageRenderer<?> renderer = produce(TileDataImageRenderer.class);
-			if (null != renderer) {
-				Pair<Double, Double> extrema = renderer.getLevelExtrema(this);
+			TileTransformer<?> tileTransformer = produce(TileTransformer.class);
+			if (null != tileTransformer) {
+				Pair<Double, Double> extrema = tileTransformer.getTransformedExtrema(this);
 				_transformFactory.setExtrema(extrema.getFirst(), extrema.getSecond());
 			}
 		} catch (ConfigurationException e) {

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/TileDataImageRenderer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/TileDataImageRenderer.java
@@ -33,9 +33,9 @@ import com.oculusinfo.factory.ConfigurationException;
 import java.awt.image.BufferedImage;
 
 /**
- * A class to encapsulate rendering of tiles into any format potentially used 
+ * A class to encapsulate rendering of tiles into any format potentially used
  * by the client.  Currently supported formats are: images, and JSON objects.
- * 
+ *
  * @author dgray, nkronenfeld
  */
 public interface TileDataImageRenderer<T> {
@@ -66,15 +66,9 @@ public interface TileDataImageRenderer<T> {
 	/**
 	 * Determine how many images are available to be rendered given a set of
 	 * input parameters
-	 * 
+	 *
 	 * @param metadata The layers meta data pyramid.
 	 * @return The number of available images
 	 */
 	public int getNumberOfImagesPerTile (PyramidMetaData metadata);
-
-	/**
-	 * From configuration information, collect metadata and figure out level extrema as needed and possible.
-	 * @throws ConfigurationException 
-	 */
-	public abstract Pair<Double, Double> getLevelExtrema (LayerConfiguration config) throws ConfigurationException;
 }

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/impl/NumberImageRenderer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/impl/NumberImageRenderer.java
@@ -61,28 +61,6 @@ public class NumberImageRenderer implements TileDataImageRenderer<Number> {
 		return new TypeDescriptor(getAcceptedBinClass());
 	}
 
-
-	private double parseExtremum (LayerConfiguration parameter, StringProperty property, String propName, String layer, double def) {
-		String rawValue = parameter.getPropertyValue(property);
-		try {
-			return Double.parseDouble(rawValue);
-		} catch (NumberFormatException|NullPointerException e) {
-			LOGGER.warn("Bad "+propName+" value "+rawValue+" for "+layer+", defaulting to "+def);
-			return def;
-		}
-	}
-
-	/* (non-Javadoc)
-	 * @see TileDataImageRenderer#getLevelExtrema()
-	 */
-	@Override
-	public Pair<Double, Double> getLevelExtrema (LayerConfiguration config) throws ConfigurationException {
-		String layer = config.getPropertyValue(LayerConfiguration.LAYER_ID);
-		double minimumValue = parseExtremum(config, LayerConfiguration.LEVEL_MINIMUMS, "minimum", layer, 0.0);
-		double maximumValue = parseExtremum(config, LayerConfiguration.LEVEL_MAXIMUMS, "maximum", layer, 1000.0);
-		return new Pair<>(minimumValue,  maximumValue);
-	}
-
 	/* (non-Javadoc)
 	 * @see TileDataImageRenderer#render(LayerConfiguration)
 	 */

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/impl/NumberListHeatMapImageRenderer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/impl/NumberListHeatMapImageRenderer.java
@@ -26,7 +26,9 @@ package com.oculusinfo.tile.rendering.impl;
 
 import java.awt.Color;
 import java.awt.image.BufferedImage;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.oculusinfo.tile.rendering.LayerConfiguration;
 import com.oculusinfo.tile.rendering.TileDataImageRenderer;
@@ -54,94 +56,77 @@ import com.oculusinfo.factory.properties.StringProperty;
 
 public class NumberListHeatMapImageRenderer implements TileDataImageRenderer<List<Number>> {
 
-	private final Logger LOGGER = LoggerFactory.getLogger(getClass());
+	private static final Logger LOGGER = LoggerFactory.getLogger(NumberListHeatMapImageRenderer.class);
 	private static final Color COLOR_BLANK = new Color(255,255,255,0);
-	private static final double pow2(double x) { return x*x; }	//in-line func for squaring a number (instead of calling Math.pow(x, 2.0) 
-	
-    // This is the only way to get a generified class; because of type erasure,
-    // it is definitionally accurate.
-    @SuppressWarnings({ "unchecked", "rawtypes" })
-    public Class<List<Number>> getAcceptedBinClass () {
-        return (Class) List.class;
-    }
+	private static final double pow2(double x) { return x*x; }	//in-line func for squaring a number (instead of calling Math.pow(x, 2.0)
 
-    public TypeDescriptor getAcceptedTypeDescriptor () {
-        return new TypeDescriptor(List.class, new TypeDescriptor(Number.class));
-    }
-
-
-    private double parseExtremum (LayerConfiguration parameter, StringProperty property, String propName, String layer, double def) {
-        String rawValue = parameter.getPropertyValue(property);
-        try {
-            return Double.parseDouble(rawValue);
-        } catch (NumberFormatException|NullPointerException e) {
-            LOGGER.info("Bad "+propName+" value "+rawValue+" for "+layer+", defaulting to "+def);
-            return def;
-        }
-    }
-
-
-	@Override
-	public Pair<Double, Double> getLevelExtrema (LayerConfiguration config) throws ConfigurationException {
-		String layer = config.getPropertyValue(LayerConfiguration.LAYER_ID);
-		double minimumValue = parseExtremum(config, LayerConfiguration.LEVEL_MINIMUMS, "minimum", layer, 0.0);
-		double maximumValue = parseExtremum(config, LayerConfiguration.LEVEL_MAXIMUMS, "maximum", layer, 1000.0);
-		return new Pair<>(minimumValue,  maximumValue);
+	// This is the only way to get a generified class; because of type erasure,
+	// it is definitionally accurate.
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public Class<List<Number>> getAcceptedBinClass () {
+		return (Class) List.class;
 	}
 
+	public TypeDescriptor getAcceptedTypeDescriptor () {
+		return new TypeDescriptor(List.class, new TypeDescriptor(Number.class));
+	}
 
 	/* (non-Javadoc)
 	 * @see TileDataImageRenderer#render(LayerConfiguration)
 	 */
-    public BufferedImage render (TileData<List<Number>> data, LayerConfiguration config) {
-        BufferedImage bi;
-        String layerId = config.getPropertyValue(LayerConfiguration.LAYER_ID);
-        TileIndex index = config.getPropertyValue(LayerConfiguration.TILE_COORDINATE);
-        try {
-            int outputWidth = config.getPropertyValue(LayerConfiguration.OUTPUT_WIDTH);
-            int outputHeight = config.getPropertyValue(LayerConfiguration.OUTPUT_HEIGHT);
-            int rangeMax = config.getPropertyValue(LayerConfiguration.RANGE_MAX);
-            int rangeMin = config.getPropertyValue(LayerConfiguration.RANGE_MIN);
+	public BufferedImage render (TileData<List<Number>> data, LayerConfiguration config) {
+		BufferedImage bi;
+		String layerId = config.getPropertyValue(LayerConfiguration.LAYER_ID);
+		TileIndex index = config.getPropertyValue(LayerConfiguration.TILE_COORDINATE);
+
+		Map<Double, Double> inout = new HashMap<>();
+
+		try {
+			int outputWidth = config.getPropertyValue(LayerConfiguration.OUTPUT_WIDTH);
+			int outputHeight = config.getPropertyValue(LayerConfiguration.OUTPUT_HEIGHT);
+			int rangeMax = config.getPropertyValue(LayerConfiguration.RANGE_MAX);
+			int rangeMin = config.getPropertyValue(LayerConfiguration.RANGE_MIN);
 			String rangeMode = config.getPropertyValue(LayerConfiguration.RANGE_MODE);
 			String pixelShape = config.getPropertyValue(LayerConfiguration.PIXEL_SHAPE);
-			
-            bi = new BufferedImage(outputWidth, outputHeight, BufferedImage.TYPE_INT_ARGB);
 
-            @SuppressWarnings("unchecked")
-            ValueTransformer<Number> t = config.produce(ValueTransformer.class);
-            int[] rgbArray = new int[outputWidth*outputHeight];
+			bi = new BufferedImage(outputWidth, outputHeight, BufferedImage.TYPE_INT_ARGB);
 
-            double scaledMax = (double)rangeMax/100;
-            double scaledMin = (double)rangeMin/100;
-            double oneOverScaledRange = 1.0 / (scaledMax - scaledMin);
+			@SuppressWarnings("unchecked")
+			ValueTransformer<Number> t = config.produce(ValueTransformer.class);
+			int[] rgbArray = new int[outputWidth*outputHeight];
 
-            int xBins = data.getDefinition().getXBins();
-            int yBins = data.getDefinition().getYBins();
+			double scaledMax = (double)rangeMax/100;
+			double scaledMin = (double)rangeMin/100;
+			double oneOverScaledRange = 1.0 / (scaledMax - scaledMin);
 
-            double xScale = ((double) bi.getWidth())/xBins;
-            double yScale = ((double) bi.getHeight())/yBins;
-        	double radius2 = pow2(Math.min(xScale, yScale)*0.5);	// min squared 'radius' of final scaled bin
-    		boolean bCoarseCircles = pixelShape.equals("circle");	// render 'coarse' bins as circles or squares?
-    		
-            ColorRamp colorRamp = config.produce(ColorRamp.class);
-            
-    		if ((xScale==1.0) && (yScale==1.0)) {
-    			// no bin scaling needed
+			int xBins = data.getDefinition().getXBins();
+			int yBins = data.getDefinition().getYBins();
 
-	            for(int ty = 0; ty < yBins; ty++){
-	                for(int tx = 0; tx < xBins; tx++){
-	                    List<Number> binContents = data.getBin(tx, ty);
-	                    double binCount = 0;
-	                    for(int i = 0; i < binContents.size(); i++) {
-	                    	if ( binContents.get(i) != null ) {
-	                    		binCount = binCount + binContents.get(i).doubleValue();
-	                    	}
-	                    }
-	
-	                    //log/linear
-	                    double transformedValue = t.transform(binCount).doubleValue();
-	                    int rgb;
-	                    if ((rangeMode.equals("dropZero") && binCount != 0) || binCount > 0) {
+			double xScale = ((double) bi.getWidth())/xBins;
+			double yScale = ((double) bi.getHeight())/yBins;
+			double radius2 = pow2(Math.min(xScale, yScale)*0.5);	// min squared 'radius' of final scaled bin
+			boolean bCoarseCircles = pixelShape.equals("circle");	// render 'coarse' bins as circles or squares?
+
+			ColorRamp colorRamp = config.produce(ColorRamp.class);
+
+			if ((xScale==1.0) && (yScale==1.0)) {
+				// no bin scaling needed
+
+				for(int ty = 0; ty < yBins; ty++){
+					for(int tx = 0; tx < xBins; tx++){
+						List<Number> binContents = data.getBin(tx, ty);
+						double binCount = 0;
+						for(int i = 0; i < binContents.size(); i++) {
+							if ( binContents.get(i) != null ) {
+								binCount = binCount + binContents.get(i).doubleValue();
+							}
+						}
+
+						//log/linear
+						double transformedValue = t.transform(binCount).doubleValue();
+						inout.put(binCount, transformedValue);
+						int rgb;
+						if ((rangeMode.equals("dropZero") && binCount != 0) || binCount > 0) {
 							if ( rangeMode.equals("cull") ) {
 								if ( transformedValue >= scaledMin && transformedValue <= scaledMax ) {
 									rgb = colorRamp.getRGB( ( transformedValue - scaledMin ) * oneOverScaledRange );
@@ -151,41 +136,42 @@ public class NumberListHeatMapImageRenderer implements TileDataImageRenderer<Lis
 							}  else {
 								rgb = colorRamp.getRGB( ( transformedValue - scaledMin ) * oneOverScaledRange );
 							}
-	                    } else {
-	                        rgb = COLOR_BLANK.getRGB();
-	                    }
-	                    
+						} else {
+							rgb = COLOR_BLANK.getRGB();
+						}
+
 						//'draw' out the scaled 'pixel'
 						int i = ty*bi.getWidth() + tx;
-						rgbArray[i] = rgb;       
-	                }
-	            }
-    		}
-    		else {
-    			// perform bin scaling (i.e. if bin coarseness != 1.0)
+						rgbArray[i] = rgb;
+					}
+				}
+			}
+			else {
+				// perform bin scaling (i.e. if bin coarseness != 1.0)
 
-	            for(int ty = 0; ty < yBins; ty++){
-	                for(int tx = 0; tx < xBins; tx++){
-	                    //calculate the scaled dimensions of this 'pixel' within the image
-	                    int minX = (int) Math.round(tx*xScale);
-	                    int maxX = (int) Math.round((tx+1)*xScale);
-	                    int minY = (int) Math.round(ty*yScale);
-	                    int maxY = (int) Math.round((ty+1)*yScale);
+				for(int ty = 0; ty < yBins; ty++){
+					for(int tx = 0; tx < xBins; tx++){
+						//calculate the scaled dimensions of this 'pixel' within the image
+						int minX = (int) Math.round(tx*xScale);
+						int maxX = (int) Math.round((tx+1)*xScale);
+						int minY = (int) Math.round(ty*yScale);
+						int maxY = (int) Math.round((ty+1)*yScale);
 						double centreX = (maxX + minX) * 0.5;
-						double centreY = (maxY + minY) * 0.5;              
-	
-	                    List<Number> binContents = data.getBin(tx, ty);
-	                    double binCount = 0;
-	                    for(int i = 0; i < binContents.size(); i++) {
-	                    	if ( binContents.get(i) != null ) {
-	                    		binCount = binCount + binContents.get(i).doubleValue();
-	                    	}
-	                    }
-	
-	                    //log/linear
-	                    double transformedValue = t.transform(binCount).doubleValue();
-	                    int rgb;
-	                    if ((rangeMode.equals("dropZero") && binCount != 0) || binCount > 0) {
+						double centreY = (maxY + minY) * 0.5;
+
+						List<Number> binContents = data.getBin(tx, ty);
+						double binCount = 0;
+						for(int i = 0; i < binContents.size(); i++) {
+							if ( binContents.get(i) != null ) {
+								binCount = binCount + binContents.get(i).doubleValue();
+							}
+						}
+
+						//log/linear
+						double transformedValue = t.transform(binCount).doubleValue();
+						inout.put(binCount, transformedValue);
+						int rgb;
+						if ((rangeMode.equals("dropZero") && binCount != 0) || binCount > 0) {
 							if ( rangeMode.equals("cull") ) {
 								if ( transformedValue >= scaledMin && transformedValue <= scaledMax ) {
 									rgb = colorRamp.getRGB( ( transformedValue - scaledMin ) * oneOverScaledRange );
@@ -195,15 +181,15 @@ public class NumberListHeatMapImageRenderer implements TileDataImageRenderer<Lis
 							}  else {
 								rgb = colorRamp.getRGB( ( transformedValue - scaledMin ) * oneOverScaledRange );
 							}
-	                    } else {
-	                        rgb = COLOR_BLANK.getRGB();
-	                    }
-	
+						} else {
+							rgb = COLOR_BLANK.getRGB();
+						}
+
 						//'draw' out the scaled 'pixel'
 						if (bCoarseCircles && radius2 > 1.0) {
 							// draw scaled (coarse) bin as a circle (Note: need radius to be > 1.0 pixels in order to render a circle)
 							for (int ix = minX; ix < maxX; ++ix) {
-								for (int iy = minY; iy < maxY; ++iy) {							
+								for (int iy = minY; iy < maxY; ++iy) {
 									int i = iy*bi.getWidth() + ix;
 									double dist = (pow2(ix+0.5-centreX) + pow2(iy+0.5-centreY));
 									if (dist <= radius2) {
@@ -212,7 +198,7 @@ public class NumberListHeatMapImageRenderer implements TileDataImageRenderer<Lis
 										rgbArray[i] = COLOR_BLANK.getRGB();	// scaled bin is outside bin's valid radius, so force to be blank
 									}
 								}
-							}										
+							}
 						}
 						else {
 							// draw scaled bin simply as a square
@@ -223,17 +209,17 @@ public class NumberListHeatMapImageRenderer implements TileDataImageRenderer<Lis
 								}
 							}
 						}
-	                }
-	            }
-    		}
+					}
+				}
+			}
 
-            bi.setRGB(0, 0, outputWidth, outputHeight, rgbArray, 0, outputWidth);
-        } catch (Exception e) {
-            LOGGER.error("Tile error: " + layerId + ":" + index, e);
-            bi = null;
-        }
-        return bi;
-    }
+			bi.setRGB(0, 0, outputWidth, outputHeight, rgbArray, 0, outputWidth);
+		} catch (Exception e) {
+			LOGGER.error("Tile error: " + layerId + ":" + index, e);
+			bi = null;
+		}
+		return bi;
+	}
 
 
 	/**

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/impl/NumberStatisticImageRenderer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/impl/NumberStatisticImageRenderer.java
@@ -55,7 +55,7 @@ import com.oculusinfo.tile.util.GraphicsUtilities;
 /**
  * An image renderer that works off of tile grids, but instead of rendering
  * a heatmap, calculates some statistics and renders them as text.
- * 
+ *
  * @author  dgray
  */
 public class NumberStatisticImageRenderer implements TileDataImageRenderer<Number> {
@@ -72,15 +72,7 @@ public class NumberStatisticImageRenderer implements TileDataImageRenderer<Numbe
 	public TypeDescriptor getAcceptedTypeDescriptor() {
 		return new TypeDescriptor(getAcceptedBinClass());
 	}
-	
 
-	/* (non-Javadoc)
-	 * @see TileDataImageRenderer#getLevelExtrema(LayerConfiguration)
-	 */
-	@Override
-	public Pair<Double, Double> getLevelExtrema (LayerConfiguration config) throws ConfigurationException {
-		return new Pair<Double, Double>(0.0, 0.0);
-	}
 
 	/* (non-Javadoc)
 	 * @see TileDataImageRenderer#render(LayerConfiguration)
@@ -90,47 +82,47 @@ public class NumberStatisticImageRenderer implements TileDataImageRenderer<Numbe
 		BufferedImage bi;
 		String layerId = config.getPropertyValue(LayerConfiguration.LAYER_ID);
 		TileIndex index = config.getPropertyValue(LayerConfiguration.TILE_COORDINATE);
- 		
+
 		try {
 			index = config.getPropertyValue(LayerConfiguration.TILE_COORDINATE);
 			int width = config.getPropertyValue(LayerConfiguration.OUTPUT_WIDTH);
 			int height = config.getPropertyValue(LayerConfiguration.OUTPUT_HEIGHT);
 
 			bi = GraphicsUtilities.createCompatibleTranslucentImage(width, height);
-		
+
 			int xBins = data.getDefinition().getXBins();
 			int yBins = data.getDefinition().getYBins();
-			
+
 			double totalBinCount = 0;
 			double maxBinCount = 0;
 			double totalNonEmptyBins = 0;
-			
+
 			for(int ty = 0; ty < yBins; ty++){
 				for(int tx = 0; tx < xBins; tx++){
 
 					double binCount = data.getBin(tx, ty).doubleValue();
 					if (binCount > 0 ){
-						
+
 						totalNonEmptyBins += 1;
-						
+
 						if(binCount > maxBinCount){
 							maxBinCount = binCount;
 						}
 						totalBinCount += binCount;
-					}					
+					}
 				}
 			}
-			
+
 			double coverage = totalNonEmptyBins/(xBins*yBins);
 
 			DecimalFormat decFormat = new DecimalFormat("");
 			String formattedTotal 		= decFormat.format(totalBinCount) + " events   ";
 			decFormat = new DecimalFormat("##.##");
 			String formattedCoverage 	= decFormat.format(coverage * 100) + "% coverage";
-			
+
 			String text = layerId + ": " + formattedTotal + " " + formattedCoverage;
 			drawTextGlow(bi, text, 5, 10, FONT, Color.white, Color.black);
-					
+
 		} catch (Exception e) {
 			LOGGER.debug("Tile is corrupt: " + layerId + ":" + index);
 			LOGGER.debug("Tile error: ", e);
@@ -138,11 +130,11 @@ public class NumberStatisticImageRenderer implements TileDataImageRenderer<Numbe
 		}
 		return bi;
 	}
-	
+
 	/**
 	 * Draw a line of text with a glow around it. Uses fast blurring approximation of gaussian.
 	 * TODO: Support calling this multiple times! currently wipes out anything that was there before.
-	 * 
+	 *
 	 * @param destination
 	 * @param text
 	 * @param xOffset
@@ -158,25 +150,25 @@ public class NumberStatisticImageRenderer implements TileDataImageRenderer<Numbe
 		FontMetrics fm = g.getFontMetrics();
 		Rectangle2D bounds = fm.getStringBounds(text, g);
 		FontRenderContext frc = g.getFontRenderContext();
-		
-		TextLayout layout = new TextLayout(text, g.getFont(), frc);			
+
+		TextLayout layout = new TextLayout(text, g.getFont(), frc);
 		float sw = (float) layout.getBounds().getWidth();
 		float sh = (float) layout.getBounds().getHeight();
 		Shape shape = layout.getOutline(AffineTransform.getTranslateInstance(
-		                                                                     bounds.getWidth()/2-sw/2 + xOffset, 
+		                                                                     bounds.getWidth()/2-sw/2 + xOffset,
 		                                                                     bounds.getHeight()*0.5+sh/2 + yOffset));
-		
+
 		BufferedImage biText = GraphicsUtilities.createCompatibleImage(destination);
 		Graphics2D gText = biText.createGraphics(); // { gText
 		gText.setFont(g.getFont());
 		gText.setColor(glowColor);
 		gText.setStroke(new BasicStroke(2));
 		gText.draw(shape);
-		gText.dispose(); // } End gText	
-		
+		gText.dispose(); // } End gText
+
 		StackBlurFilter blur = new StackBlurFilter(3, 3);
 		blur.filter(biText, destination);
-		
+
 		g.setColor(textColor);
 		g.fill(shape);
 		g.dispose();

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/impl/TopTextScoresImageRenderer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/impl/TopTextScoresImageRenderer.java
@@ -46,11 +46,11 @@ import java.util.List;
 /**
  * A server side to render Map<String, Double> (well, technically,
  * List<Pair<String, Double>>) tiles.
- * 
+ *
  * This renderer by default renders the top scores, rendering up to 10 per bin.
  * To render more, fewer, or different texts, override
  * {@link #getTextsToDraw(List)}.
- * 
+ *
  * @author nkronenfeld
  */
 public class TopTextScoresImageRenderer implements TileDataImageRenderer<List<Pair<String, Double>>> {
@@ -106,11 +106,6 @@ public class TopTextScoresImageRenderer implements TileDataImageRenderer<List<Pa
 			int textWidth = metrics.stringWidth(text);
 			g.drawString(text, centerX-padding-textWidth, textBaseline);
 		}
-	}
-
-	@Override
-	public Pair<Double, Double> getLevelExtrema (LayerConfiguration config) throws ConfigurationException {
-		return new Pair<Double, Double>(0.0, 0.0);
 	}
 
 	/**

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/AvgDivBucketTileTransformer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/AvgDivBucketTileTransformer.java
@@ -126,7 +126,7 @@ public class AvgDivBucketTileTransformer<T extends Number> implements TileTransf
 		AverageTileBucketView<T> denominator = new AverageTileBucketView<>(inputData, startA, endA);
 		BinaryOperationTileView<T> binaryOpView = new BinaryOperationTileView<>(
 			numerator, denominator, BinaryOperator.OPERATOR_TYPE.DIVIDE, 1.0);
-		return new UnaryOperationTileView<>(UnaryOperator.OPERATOR_TYPE.LOG_10, binaryOpView, 0.0);
+		return new UnaryOperationTileView<>(UnaryOperator.OPERATOR_TYPE.LOG_10, binaryOpView, -(Math.log10(_averageRange)));
 	}
 
 	@Override

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/DivisionBucketTileTransformer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/DivisionBucketTileTransformer.java
@@ -31,6 +31,9 @@ import com.oculusinfo.binning.TileData;
 import com.oculusinfo.binning.impl.AverageTileBucketView;
 import com.oculusinfo.binning.impl.OperationTileBucketView;
 
+import com.oculusinfo.factory.ConfigurationException;
+import com.oculusinfo.factory.util.Pair;
+import com.oculusinfo.tile.rendering.LayerConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.json.JSONArray;
@@ -46,26 +49,21 @@ import org.json.JSONObject;
  *
  */
 
-public class OperatorBucketTileTransformer<T> implements TileTransformer<List<T>> {
-	private static final Logger LOGGER = LoggerFactory.getLogger( OperatorBucketTileTransformer.class );
+public class DivisionBucketTileTransformer<T> implements TileTransformer<List<T>> {
+	private static final Logger LOGGER = LoggerFactory.getLogger( DivisionBucketTileTransformer.class );
 
-	private Integer _averageRange 	= 0;
-	private Integer _startBucket 	= 0;
-	private Integer _endBucket 		= 0;
-	private String  _operator 		= "";
+	protected Integer _averageRange 	= 0;
+	protected Integer _startBucket 	= 0;
+	protected Integer _endBucket 		= 0;
 
-
-	public OperatorBucketTileTransformer(JSONObject arguments){
+	public DivisionBucketTileTransformer(JSONObject arguments){
 		if ( arguments != null ) {
 			// get the start and end time range
 			_averageRange 	= arguments.optInt("averageRange");
 			_startBucket 	= arguments.optInt("startBucket");
 			_endBucket 		= arguments.optInt("endBucket");
-
-			// get the operator
-			_operator = arguments.optString("operator");
 		} else {
-			LOGGER.warn("No arguements passed in to filterbucket transformer");
+			LOGGER.warn("No arguments passed in to filterbucket transformer");
 		}
 	}
 
@@ -93,7 +91,7 @@ public class OperatorBucketTileTransformer<T> implements TileTransformer<List<T>
 		int halfRange = (int) Math.floor(_averageRange/2);
 		JSONArray maxBuckets = new JSONArray(inputData.getMetaData("maximum array"));
 		int lastBucket = maxBuckets.length()-1;
-		
+
 		int startA = 0;
 		int endA = 0;
 		// if range is larger than number of buckets, use all buckets for average
@@ -118,10 +116,15 @@ public class OperatorBucketTileTransformer<T> implements TileTransformer<List<T>
 					endA++;
 				}
 			}
-		}		
+		}
 		AverageTileBucketView<T> opTileA = new AverageTileBucketView<>(inputData, startA, endA);
 		AverageTileBucketView<T> opTileB = new AverageTileBucketView<>(inputData, _startBucket, _endBucket);
-		return new OperationTileBucketView<>( opTileA, opTileB, _operator );
+		return new OperationTileBucketView<>( opTileA, opTileB, "//");
+	}
+
+	@Override
+	public Pair<Double, Double> getTransformedExtrema(LayerConfiguration config) throws ConfigurationException {
+		return new Pair<>(1.0/_averageRange, (double) _averageRange);
 	}
 
 }

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/FilterByBucketTileTransformer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/FilterByBucketTileTransformer.java
@@ -25,11 +25,17 @@
 package com.oculusinfo.tile.rendering.transformations.tile;
 
 
+import java.util.ArrayList;
 import java.util.List;
 
 import com.oculusinfo.binning.TileData;
 import com.oculusinfo.binning.impl.FilterTileBucketView;
 
+import com.oculusinfo.factory.ConfigurationException;
+import com.oculusinfo.factory.properties.StringProperty;
+import com.oculusinfo.factory.util.Pair;
+import com.oculusinfo.tile.rendering.LayerConfiguration;
+import org.json.JSONArray;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.json.JSONException;
@@ -49,14 +55,15 @@ public class FilterByBucketTileTransformer<T> implements TileTransformer<List<T>
 
 	private Integer _startBucket = null;
 	private Integer _endBucket = null;
+	private List<Double> _minVals = null;
+	private List<Double> _maxVals = null;
+
 
 	public FilterByBucketTileTransformer(JSONObject arguments){
 		if ( arguments != null ) {
 			// get the start and end time range
 			_startBucket = arguments.optInt("startBucket");
 			_endBucket = arguments.optInt("endBucket");
-		} else {
-			LOGGER.warn("No arguements passed in to filterbucket transformer");
 		}
 	}
 
@@ -83,4 +90,71 @@ public class FilterByBucketTileTransformer<T> implements TileTransformer<List<T>
 		return new FilterTileBucketView<>(inputData, _startBucket, _endBucket);
 	}
 
+	@Override
+	public Pair<Double, Double> getTransformedExtrema(LayerConfiguration config) throws ConfigurationException {
+		// Parse the mins and maxes for the buckets out of the supplied JSON.
+		if (_minVals == null) {
+			String layer = config.getPropertyValue(LayerConfiguration.LAYER_ID);
+			_minVals = parseExtremum(config, LayerConfiguration.LEVEL_MINIMUMS, "minimum", layer, 0.0);
+			_maxVals = parseExtremum(config, LayerConfiguration.LEVEL_MAXIMUMS, "maximum", layer, 1000.0);
+			if (_startBucket == null) {
+				_startBucket = 0;
+				_endBucket = _minVals.size();
+			}
+		}
+		// Compute the min/max for the range of buckets.
+		double minimumValue = Double.MIN_VALUE;
+		double maximumValue = -Double.MAX_VALUE;
+		if (_startBucket == _endBucket) {
+			minimumValue = _minVals.get(_startBucket);
+			maximumValue = _maxVals.get(_startBucket);
+		} else {
+			for (int i = _startBucket; i < _endBucket; i++) {
+				Double val = _minVals.get(i);
+				if (val < minimumValue) {
+					minimumValue = val;
+				}
+				val = _maxVals.get(i);
+				if (val > maximumValue) {
+					maximumValue = val;
+				}
+			}
+		}
+
+		return new Pair<>(minimumValue,  maximumValue);
+	}
+
+	// Extracts all the extrema
+	private List<Double> parseExtremum (LayerConfiguration parameter, StringProperty property, String propName,
+										String layer, Double def) {
+		String rawValue = parameter.getPropertyValue(property);
+		ArrayList<Double> values = null;
+
+		// If the is no extremum info available return the default.
+		if (rawValue == null) {
+			values = new ArrayList<>(1);
+			values.add(def);
+			return values;
+		}
+
+		// Convert string into json object
+		try {
+			JSONArray ex = new JSONArray(rawValue);
+			values = new ArrayList<>(ex.length());
+			for (int i = 0; i < ex.length(); i++) {
+				values.add(ex.getJSONObject(i).getDouble(propName));
+			}
+			return values;
+		} catch (NumberFormatException|NullPointerException e) {
+			LOGGER.warn("Bad " + propName + " value " + rawValue + " for " + layer + ", defaulting to " + def);
+			values.clear();
+			values.add(def);
+			return values;
+		} catch (JSONException e) {
+			LOGGER.warn("JSON parse exception", e);
+			values.clear();
+			values.add(def);
+			return values;
+		}
+	}
 }

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/FilterTopicByBucketTileTransformer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/FilterTopicByBucketTileTransformer.java
@@ -28,6 +28,9 @@ import java.util.List;
 
 import com.oculusinfo.binning.TileData;
 
+import com.oculusinfo.factory.ConfigurationException;
+import com.oculusinfo.factory.util.Pair;
+import com.oculusinfo.tile.rendering.LayerConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.json.JSONArray;
@@ -70,12 +73,12 @@ public class FilterTopicByBucketTileTransformer<T> implements TileTransformer<Li
 	}
 
 	@Override
-    public TileData<List<T>> transform (TileData<List<T>> inputData) throws Exception {
-    	TileData<List<T>> resultTile = inputData;
+	public TileData<List<T>> transform (TileData<List<T>> inputData) throws Exception {
+		TileData<List<T>> resultTile = inputData;
 
-    	// add in metadata to the tile
-        JSONObject metadata = new JSONObject(inputData.getMetaData("meta"));
-        JSONObject filteredMetadata = null;
+		// add in metadata to the tile
+		JSONObject metadata = new JSONObject(inputData.getMetaData("meta"));
+		JSONObject filteredMetadata = null;
 		if ( metadata.length() > 0 ) {
 			filteredMetadata = filterKeywordMetadata(metadata);
 			if (null != filteredMetadata) {
@@ -83,14 +86,15 @@ public class FilterTopicByBucketTileTransformer<T> implements TileTransformer<Li
 			}
 		}
 
-        return resultTile;
-    }
+		return resultTile;
+	}
 
-    public JSONObject filterKeywordMetadata(JSONObject inputMetadata) throws JSONException {
-    	if ( _startBucket != null && _endBucket != null ) {
+
+	public JSONObject filterKeywordMetadata(JSONObject inputMetadata) throws JSONException {
+		if ( _startBucket != null && _endBucket != null ) {
 			if ( _startBucket < 0 || _startBucket > _endBucket ) {
 				throw new IllegalArgumentException("Filter by keyword bucket transformer arguments are invalid.  start time bucket: " + _startBucket + ", end time bucket: " + _endBucket);
-        	}
+			}
 		}
 
 		JSONObject map = inputMetadata.getJSONObject("map");
@@ -112,5 +116,11 @@ public class FilterTopicByBucketTileTransformer<T> implements TileTransformer<Li
 		map.put("bins", filteredBins);
 
 		return inputMetadata;
-    }
+	}
+
+	@Override
+	public Pair<Double, Double> getTransformedExtrema(LayerConfiguration config) throws ConfigurationException {
+		return new Pair<>(0.0d, 0.0);
+	}
+
 }

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/FilterVarsDoubleArrayTileTransformer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/FilterVarsDoubleArrayTileTransformer.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2014 Oculus Info Inc. 
+ * Copyright (c) 2014 Oculus Info Inc.
  * http://www.oculusinfo.com/
- * 
+ *
  * Released under the MIT License.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to
@@ -24,33 +24,40 @@
  */
 package com.oculusinfo.tile.rendering.transformations.tile;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.oculusinfo.binning.TileData;
 import com.oculusinfo.binning.TileIndex;
 import com.oculusinfo.binning.impl.DenseTileData;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.oculusinfo.factory.ConfigurationException;
+import com.oculusinfo.factory.properties.StringProperty;
+import com.oculusinfo.factory.util.Pair;
+import com.oculusinfo.tile.rendering.LayerConfiguration;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.oculusinfo.tile.rendering.LayerConfiguration.*;
 
 
-/** 
- * 	This transformer will take in JSON or tileData object representing bins of a double array 
+/**
+ * 	This transformer will take in JSON or tileData object representing bins of a double array
  * 		tile and will filter out all variables except the variables contained in the variable
- * 		array passed in during construction.  The double arrays passed back will be in the 
+ * 		array passed in during construction.  The double arrays passed back will be in the
  * 		order that they are sequenced in the JSON or tileData array passed in.
- * 
+ *
  */
 
 public class FilterVarsDoubleArrayTileTransformer<T> implements TileTransformer<List<T>> {
 	private static final Logger LOGGER = LoggerFactory.getLogger(FilterVarsDoubleArrayTileTransformer.class);
-	
+
 	private List<Integer> _variables = new ArrayList<>();
-	
+	private List<Double> _minVals = null;
+	private List<Double> _maxVals = null;
+
 	public FilterVarsDoubleArrayTileTransformer(JSONObject variables){
 		// Get the JSONArray out of the variables JSONObject
 		try {
@@ -70,13 +77,13 @@ public class FilterVarsDoubleArrayTileTransformer<T> implements TileTransformer<
 		}
 	}
 
-	// For each bin in the tile described by the input JSON, extract the values from the 
+	// For each bin in the tile described by the input JSON, extract the values from the
 	//	bin's array only at the indexes stored in the _variables list and build the resulting'
 	// 	JSON based on this criteria
 	@Override
 	public JSONObject transform (JSONObject inputJSON) throws JSONException {
 		JSONObject resultJSON;
-		
+
 		if ( _variables == null ) {
 			resultJSON = inputJSON;
 		}
@@ -91,22 +98,22 @@ public class FilterVarsDoubleArrayTileTransformer<T> implements TileTransformer<
 			JSONArray bins = inputJSON.getJSONArray("values");
 			JSONArray resultBins = new JSONArray();
 
-			for (int binIndex = 0; binIndex < bins.length(); binIndex++) {				
+			for (int binIndex = 0; binIndex < bins.length(); binIndex++) {
 				JSONObject singleBin = bins.getJSONObject (binIndex);
 				JSONArray valuesInBin = singleBin.getJSONArray("value");
-				
+
 				JSONObject resultSingleBin = new JSONObject();
 				JSONArray resultValuesInSingleBin = new JSONArray();
-					
-				// just loop through variable indexes in _variables			
+
+				// just loop through variable indexes in _variables
 				for (int varIndex = 0; varIndex < _variables.size(); varIndex++) {
-					int arrayIndex = _variables.get(varIndex);					
+					int arrayIndex = _variables.get(varIndex);
 					if (arrayIndex < valuesInBin.length()) {
-						JSONObject value = valuesInBin.getJSONObject(arrayIndex);						
+						JSONObject value = valuesInBin.getJSONObject(arrayIndex);
 						JSONObject resultValue = new JSONObject();
 						resultValue.put("value", value.getDouble("value"));
 						resultValuesInSingleBin.put(resultValue);
-					}					
+					}
 				}
 				resultSingleBin.put("value", resultValuesInSingleBin);
 				resultBins.put(resultSingleBin);
@@ -150,4 +157,53 @@ public class FilterVarsDoubleArrayTileTransformer<T> implements TileTransformer<
         return resultTile;
     }
 
+	@Override
+	public Pair<Double, Double> getTransformedExtrema(LayerConfiguration config) throws ConfigurationException {
+		// Parse the mins and maxes for the buckets out of the supplied JSON.
+		if (_minVals == null) {
+			String layer = config.getPropertyValue(LAYER_ID);
+			_minVals = parseExtremum(config, LEVEL_MINIMUMS, "minimum", layer, 0.0);
+			_maxVals = parseExtremum(config, LEVEL_MAXIMUMS, "maximum", layer, 1000.0);
+		}
+		// Compute the min/max for the range of buckets.
+		double minimumValue = Double.MIN_VALUE;
+		double maximumValue = -Double.MAX_VALUE;
+		for (Integer index: _variables) {
+			Double val = _minVals.get(index);
+			if (val < minimumValue) {
+				minimumValue = val;
+			}
+			val = _maxVals.get(index);
+			if (val > maximumValue) {
+				maximumValue = val;
+			}
+		}
+		return new Pair<>(minimumValue,  maximumValue);
+	}
+
+	// Extracts all the extrema
+	private List<Double> parseExtremum (LayerConfiguration parameter, StringProperty property, String propName,
+										String layer, Double def) {
+		String rawValue = parameter.getPropertyValue(property);
+		ArrayList<Double> values = null;
+		// Convert string into json object
+		try {
+			JSONArray ex = new JSONArray(rawValue);
+			values = new ArrayList<>(ex.length());
+			for (int i = 0; i < ex.length(); i++) {
+				values.add(ex.getJSONObject(i).getDouble(propName));
+			}
+			return values;
+		} catch (NumberFormatException|NullPointerException e) {
+			LOGGER.warn("Bad " + propName + " value " + rawValue + " for " + layer + ", defaulting to " + def);
+			values.clear();
+			values.add(def);
+			return values;
+		} catch (JSONException e) {
+			LOGGER.warn("JSON parse exception", e);
+			values.clear();
+			values.add(def);
+			return values;
+		}
+	}
 }

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/IdentityTileTransformer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/IdentityTileTransformer.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (c) 2014 Oculus Info Inc. http://www.oculusinfo.com/
- * 
+ *
  * Released under the MIT License.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,10 +24,16 @@
 package com.oculusinfo.tile.rendering.transformations.tile;
 
 
+import com.oculusinfo.factory.ConfigurationException;
+import com.oculusinfo.factory.properties.StringProperty;
+import com.oculusinfo.factory.util.Pair;
+import com.oculusinfo.tile.rendering.LayerConfiguration;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import com.oculusinfo.binning.TileData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -40,26 +46,46 @@ import com.oculusinfo.binning.TileData;
  */
 public class IdentityTileTransformer<T> implements TileTransformer<T> {
 
-    /**
-     * Transforms the tile data in JSON format based on transform type and returns result
-     *
-     * @param json representing the tile data in JSON form to be transformed
-     * @return JSONObject representing the fully transformed tile based on the transform type
-     */
-    public JSONObject transform(JSONObject json) throws JSONException {
-        return json;
-    }
+	private static final Logger LOGGER = LoggerFactory.getLogger(IdentityTileTransformer.class);
 
-    /**
-     * Same transformation on the raw tile form
-     * @param data the tile data
-     * @return returns the data
-     * @throws Exception
-     */
-    //takes tile data x returns tile data x generified on function level
-    public TileData<T> transform(TileData<T> data) throws Exception {
-        return data;
-    }
+	/**
+	 * Transforms the tile data in JSON format based on transform type and returns result
+	 *
+	 * @param json representing the tile data in JSON form to be transformed
+	 * @return JSONObject representing the fully transformed tile based on the transform type
+	 */
+	public JSONObject transform(JSONObject json) throws JSONException {
+		return json;
+	}
+
+	/**
+	 * Same transformation on the raw tile form
+	 * @param data the tile data
+	 * @return returns the data
+	 * @throws Exception
+	 */
+	//takes tile data x returns tile data x generified on function level
+	public TileData<T> transform(TileData<T> data) throws Exception {
+		return data;
+	}
+
+	@Override
+	public Pair<Double, Double> getTransformedExtrema(LayerConfiguration config) throws ConfigurationException {
+		String layer = config.getPropertyValue(LayerConfiguration.LAYER_ID);
+		double minimumValue = parseExtremum(config, LayerConfiguration.LEVEL_MINIMUMS, "minimum", layer, 0.0);
+		double maximumValue = parseExtremum(config, LayerConfiguration.LEVEL_MAXIMUMS, "maximum", layer, 1000.0);
+		return new Pair<>(minimumValue,  maximumValue);
+	}
+
+	private double parseExtremum (LayerConfiguration parameter, StringProperty property, String propName, String layer, double def) {
+		String rawValue = parameter.getPropertyValue(property);
+		try {
+			return Double.parseDouble(rawValue);
+		} catch (NumberFormatException|NullPointerException e) {
+			LOGGER.warn("Bad "+propName+" value "+rawValue+" for "+layer+", defaulting to "+def);
+			return def;
+		}
+	}
 }
 
 

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/TileTransformer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/TileTransformer.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (c) 2014 Oculus Info Inc. http://www.oculusinfo.com/
- * 
+ *
  * Released under the MIT License.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,6 +25,9 @@ package com.oculusinfo.tile.rendering.transformations.tile;
 
 
 import com.oculusinfo.binning.TileData;
+import com.oculusinfo.factory.ConfigurationException;
+import com.oculusinfo.factory.util.Pair;
+import com.oculusinfo.tile.rendering.LayerConfiguration;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -39,24 +42,33 @@ import org.json.JSONObject;
  */
 public interface TileTransformer<T> {
 
-    /**
-     * Transforms the tile data in JSON format based on transform type and returns result
-     *
-     * @param json representing the tile data in JSON form to be transformed
-     * @return JSONObject representing the fully transformed tile based on the transform type
-     */
-    public JSONObject transform(JSONObject json) throws JSONException;
+	/**
+	 * Transforms the tile data in JSON format based on transform type and returns result
+	 *
+	 * @param json representing the tile data in JSON form to be transformed
+	 * @return JSONObject representing the fully transformed tile based on the transform type
+	 */
+	JSONObject transform(JSONObject json) throws JSONException;
 
 
-    /**
-     * Same transformation on the raw tile form
-     * @param data The tile data to be transformed
-     * @return TileData containing the transformed data
-     * @throws Exception
-     */
-    //takes tile data x returns tile data x generified on function level
-    public TileData<T> transform(TileData<T> data) throws Exception;
+	/**
+	 * Same transformation on the raw tile form
+	 * @param data The tile data to be transformed
+	 * @return TileData containing the transformed data
+	 * @throws Exception
+	 */
+	//takes tile data x returns tile data x generified on function level
+	TileData<T> transform(TileData<T> data) throws Exception;
 
+
+	/**
+	 * Computes transformed level extrema from a layer configuration.
+	 *
+	 * @param config
+	 * @return
+	 * @throws ConfigurationException
+	 */
+	Pair<Double, Double> getTransformedExtrema(LayerConfiguration config) throws ConfigurationException;
 }
 
 

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/TileTransformerFactory.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/TileTransformerFactory.java
@@ -86,9 +86,9 @@ public class TileTransformerFactory extends ConfigurableFactory<TileTransformer<
 		} else if ("filtertopicbucket".equals(transformerTypes)) {
 			JSONObject arguments = getPropertyValue(INITIALIZATION_DATA);
 			return new FilterTopicByBucketTileTransformer<>(arguments);
-		} else if ("operatorbucket".equals(transformerTypes)) {
+		} else if ("avgdivbucket".equals(transformerTypes)) {
 			JSONObject arguments = getPropertyValue(INITIALIZATION_DATA);
-			return new DivisionBucketTileTransformer<>(arguments);
+			return new AvgDivBucketTileTransformer<>(arguments);
 		} else {  // 'identity' or none passed in will give the default transformer
 			return new IdentityTileTransformer<Object>();
 		}

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/TileTransformerFactory.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/TileTransformerFactory.java
@@ -88,7 +88,7 @@ public class TileTransformerFactory extends ConfigurableFactory<TileTransformer<
 			return new FilterTopicByBucketTileTransformer<>(arguments);
 		} else if ("operatorbucket".equals(transformerTypes)) {
 			JSONObject arguments = getPropertyValue(INITIALIZATION_DATA);
-			return new OperatorBucketTileTransformer<>(arguments);
+			return new DivisionBucketTileTransformer<>(arguments);
 		} else {  // 'identity' or none passed in will give the default transformer
 			return new IdentityTileTransformer<Object>();
 		}

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/value/SigmoidValueTransformer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/value/SigmoidValueTransformer.java
@@ -27,9 +27,9 @@ package com.oculusinfo.tile.rendering.transformations.value;
 /**
  * A value transformer that transforms two-tailed infinite range into a finite
  * range.  The range assumes a center of zero, and min/max defined as
- * +/-(max(abs(expectedMin),abs(expectedMax)), with the extrema mapped to +/-10
- * of the sigmoid curve.  The curve can be further scaled int the x direction for a
- * better data fit if needed.
+ * +/-(max(abs(expectedMin),abs(expectedMax)), which is then normalized to [-1, 1].
+ * A default value of .15d is used to scale the curve in the x direction, which is
+ * leaves it pretty close to the shape of the curve produced by log10.
  *
  * @author nkronenfeld
  */
@@ -38,17 +38,19 @@ public class SigmoidValueTransformer implements ValueTransformer<Double> {
 	private double _scale;
 
 	public SigmoidValueTransformer (double expectedMin, double expectedMax) {
-		this(expectedMin, expectedMax, 1d);
+		this(expectedMin, expectedMax, .15d);
 	}
 
 	public SigmoidValueTransformer (double expectedMin, double expectedMax, double scale) {
-		_scale = scale * 10d;
+		_scale = scale;
 		_distance = Math.max(Math.abs(expectedMin), Math.abs(expectedMax));
 	}
 
 	@Override
 	public Double transform (Double value) {
-		double scaledInput = value / _distance * _scale;
+		// normalize value on interval [-1.0, 1.0]
+		double normalized = value / _distance;
+		double scaledInput = normalized / _scale;
 		return (1/(1+Math.exp(-scaledInput)));
 	}
 

--- a/tile-service/src/main/java/com/oculusinfo/tile/rest/tile/TileServiceImpl.java
+++ b/tile-service/src/main/java/com/oculusinfo/tile/rest/tile/TileServiceImpl.java
@@ -178,12 +178,14 @@ public class TileServiceImpl implements TileService {
 		int coarseness = config.getPropertyValue( LayerConfiguration.COARSENESS );
 
 		@SuppressWarnings("unchecked")
-		TileTransformer<T> tileTransformer = config.produce( TileTransformer.class );
+		TileTransformer<T> tileTransformer = config.produce(TileTransformer.class);
 
-		TileData<T> data = tileDataForIndex( index, dataId, serializer, pyramidIO, coarseness );
+		TileData<T> data = tileDataForIndex(index, dataId, serializer, pyramidIO, coarseness);
+		if (data == null) {
+			return null;
+		}
 
 		data = tileTransformer.transform( data );
-
 		if ( data != null ) {
 			return renderer.render( data, config );
 		}


### PR DESCRIPTION
This change covers off two items.  The first was an issue with the computation of the level extrema for tile sets with bucket bins that was discovered when working on the second issue.  The computation was failing to properly parse the level extrema info because it gets supplied as lists (one for max, one for mins, elements corresponding to buckets), and the code was expecting a scalar values.  This resulted in the default of [0, 1000] being applied to all tile sets, leading to odd results when rendering.

The second item, and original requirement for the PR, was to ensure proper support for colour ramps when working with the delta plots that were introduced in #222.  Rather than attempt to visualize the division of average results directly, we needed to take log10 of the result, and then apply the sigmoid value transformer as the transfer function.  A new view was created to apply the log10 to the results of the avg divsion, and the sigmoid function was tweaked to get a curve close to that of a standard log curve.

The results are still somewhat noisy as the case where data appears in 1 bucket only evaluates  to the max positive value, and the case where the numerator has no data evaluates to the min negative value.
