### PR TITLE
Universal binner speedup

### DIFF
--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/datasets/TilingTask.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/datasets/TilingTask.scala
@@ -29,6 +29,8 @@ package com.oculusinfo.tilegen.datasets
 import java.lang.{Integer => JavaInt}
 import java.util.{ArrayList, Properties}
 
+import scala.collection.mutable.{Map => MutableMap}
+
 import com.oculusinfo.binning.metadata.PyramidMetaData
 import com.oculusinfo.factory.ConfigurableFactory
 import com.oculusinfo.factory.providers.FactoryProvider
@@ -304,7 +306,7 @@ abstract class TilingTask[PT: ClassTag, DT: ClassTag, AT: ClassTag, BT]
 						                                                getMinimumSegmentLength, getMaximumLeaderLength.get,
 						                                                getNumXBins, getNumYBins)
 
-					val populateFcn: (TileIndex, Array[BinIndex], PT) => Map[BinIndex, PT] =
+					val populateFcn: (TileIndex, Array[BinIndex], PT) => MutableMap[BinIndex, PT] =
 						if (drawArcs) StandardBinningFunctions.populateTileWithArcs(getMaximumLeaderLength,
 						                                                            StandardScalingFunctions.identityScale)
 						else StandardBinningFunctions.populateTileWithLineLeaders(getMaximumLeaderLength.get,

--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/tiling/BinningFunctions.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/tiling/BinningFunctions.scala
@@ -24,6 +24,10 @@
  */
 package com.oculusinfo.tilegen.tiling
 
+
+
+import scala.collection.mutable.{Map => MutableMap}
+
 import com.oculusinfo.binning.TilePyramid
 import com.oculusinfo.binning.BinIndex
 import com.oculusinfo.binning.TileIndex
@@ -95,8 +99,8 @@ trait StandardPointBinningFunctions {
 	 * Simple population function that just takes input points and outputs them, as is, in the
 	 * correct coordinate system.
 	 */
-	def populateTileIdentity[T]: (TileIndex, Array[BinIndex], T) => Map[BinIndex, T] =
-		(tile, bins, value) => bins.map(bin => (TileIndex.universalBinIndexToTileBinIndex(tile, bin).getBin, value)).toMap
+	def populateTileIdentity[T]: (TileIndex, Array[BinIndex], T) => MutableMap[BinIndex, T] =
+		(tile, bins, value) => MutableMap(bins.map(bin => (TileIndex.universalBinIndexToTileBinIndex(tile, bin).getBin, value)): _*)
 
 }
 
@@ -211,10 +215,10 @@ trait StandardLinearBinningFunctions {
 	 * Takes endpoints of line segments, and populates the tiles with the bins at which that line crosses that tile
 	 */
 	def populateTileWithLineSegments[T] (scaler: (Array[BinIndex], BinIndex, T) => T)
-	                                (tile: TileIndex, bins: Array[BinIndex], value: T): Map[BinIndex, T] = {
-		linearBinsForTile(bins(0), bins(1), tile).map(bin =>
+	                                (tile: TileIndex, bins: Array[BinIndex], value: T): MutableMap[BinIndex, T] = {
+		MutableMap(linearBinsForTile(bins(0), bins(1), tile).map(bin =>
 			(bin, scaler(bins, TileIndex.tileBinIndexToUniversalBinIndex(tile, bin), value))
-		).toMap
+		).toSeq: _*)
 	}
 
 	/**
@@ -224,10 +228,10 @@ trait StandardLinearBinningFunctions {
 	 * the leader length of either endpoint.
 	 */
 	def populateTileWithLineLeaders[T] (leaderLength: Int, scaler: (Array[BinIndex], BinIndex, T) => T)
-	                               (tile: TileIndex, bins: Array[BinIndex], value: T): Map[BinIndex, T] = {
-		closeLinearBinsForTile(bins(0), bins(1), tile, leaderLength).map(bin =>
+	                               (tile: TileIndex, bins: Array[BinIndex], value: T): MutableMap[BinIndex, T] = {
+		MutableMap(closeLinearBinsForTile(bins(0), bins(1), tile, leaderLength).map(bin =>
 			(bin, scaler(bins, TileIndex.tileBinIndexToUniversalBinIndex(tile, bin), value))
-		).toMap
+		).toSeq: _*)
 	}
 
 
@@ -564,10 +568,10 @@ trait StandardArcBinningFunctions {
 	 * the leader length of either endpoint.
 	 */
 	def populateTileWithArcs[T] (distance: Option[Int], scaler: (Array[BinIndex], BinIndex, T) => T)
-	                        (tile: TileIndex, bins: Array[BinIndex], value: T): Map[BinIndex, T] = {
-		arcBinsForTile(bins(0), bins(1), tile, distance).map(bin =>
+	                        (tile: TileIndex, bins: Array[BinIndex], value: T): MutableMap[BinIndex, T] = {
+		MutableMap(arcBinsForTile(bins(0), bins(1), tile, distance).map(bin =>
 			(bin, scaler(bins, TileIndex.tileBinIndexToUniversalBinIndex(tile, bin), value))
-		).toMap
+		).toSeq: _*)
 	}
 
 	/**

--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/tiling/UniversalBinner.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/tiling/UniversalBinner.scala
@@ -92,10 +92,17 @@ object UniversalBinner {
 	 * @tparam V The class type of the map values
 	 */
 	def aggregateMaps[K, V](aggFcn: (V, V) => V, map1: MutableMap[K, V], map2: MutableMap[K, V]): MutableMap[K, V] = {
-		map2.keys.foreach { key =>
-			map1(key) = map1.get(key).map(value => aggFcn(value, map2(key))).getOrElse(map2(key))
+		if (map1.size > map2.size) {
+			map2.keys.foreach { key =>
+				map1(key) = map1.get(key).map(value => aggFcn(value, map2(key))).getOrElse(map2(key))
+			}
+			map1
+		} else {
+			map1.keys.foreach { key =>
+				map2(key) = map2.get(key).map { value => aggFcn(value, map1(key))}.getOrElse(map1(key))
+			}
+			map2
 		}
-		map1
 	}
 
 //	def oldAggregateMaps[K, V](aggFcn: (V, V) => V, map1: MutableMap[K, V], map2: MutableMap[K, V]): MutableMap[K, V] = {

--- a/tile-generation/src/test/scala/com/oculusinfo/tilegen/tiling/BinningSupportTests.scala
+++ b/tile-generation/src/test/scala/com/oculusinfo/tilegen/tiling/BinningSupportTests.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2015 Uncharted Software Inc.
+ * http://www.oculusinfo.com/
+ *
+ * Released under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.oculusinfo.tilegen.tiling
+
+
+
+import scala.collection.mutable.{Map => MutableMap}
+
+import org.scalatest.FunSuite
+
+
+
+/**
+ * Test some of the functions used by the Universal Binner
+ */
+class BinningSupportTests extends FunSuite {
+	test("Test map aggregation") {
+		val aggFcn: (Int, Int) => Int = (n, m) => n + m
+
+		{
+			val a = MutableMap("a" -> 1, "b" -> 2, "c" -> 1)
+			val b = MutableMap("c" -> 2, "d" -> 4)
+
+			val abm = UniversalBinner.aggregateMaps(aggFcn, a, b)
+			val ab = abm.toList.sortBy(_._1)
+			// Make sure the values are correct
+			assert(List(("a", 1), ("b", 2), ("c", 3), ("d", 4)) === ab)
+			// Make sure the smaller map (b) was merged into the larger map (a)
+			assert(abm === a)
+		}
+
+		{
+			val a = MutableMap("a" -> 1, "b" -> 2, "c" -> 1)
+			val b = MutableMap("c" -> 2, "d" -> 4)
+
+			val bam = UniversalBinner.aggregateMaps(aggFcn, b, a)
+			val ba = bam.toList.sortBy(_._1)
+			// Make sure the values are correct
+			assert(List(("a", 1), ("b", 2), ("c", 3), ("d", 4)) === ba)
+			// Make sure the smaller map (b) was merged into the larger map (a)
+			assert(bam === a)
+		}
+	}
+
+	test("Test optional aggregation") {
+		val aggFcn: (Int, Int) => Int = (n, m) => n + m
+
+		// Make sure valid values are aggregated
+		assert(7 === UniversalBinner.optAggregate(Some(aggFcn), Some(3), Some(4)).get)
+		assert(4 === UniversalBinner.optAggregate(Some(aggFcn), None, Some(4)).get)
+		assert(3 === UniversalBinner.optAggregate(Some(aggFcn), Some(3), None).get)
+		// Make sure invalid values are not aggregated
+		assert(None === UniversalBinner.optAggregate(None, Some(3), Some(4)))
+		assert(None == UniversalBinner.optAggregate(Some(aggFcn), None, None))
+		assert(None == UniversalBinner.optAggregate(None, None, None))
+	}
+}

--- a/tile-generation/src/test/scala/com/oculusinfo/tilegen/tiling/RDDBinnerTests.scala
+++ b/tile-generation/src/test/scala/com/oculusinfo/tilegen/tiling/RDDBinnerTests.scala
@@ -227,7 +227,8 @@ class RDDBinnerTestSuite extends FunSuite with SharedSparkContext with TileAsser
 	}
 
 
-	test("Test tiling speed") {
+	// Test the tiling speed of the universal binner versus the old RDDBinner.
+	ignore("Test tiling speed") {
 		def time (f: () => Unit): Double = {
 			val start = System.nanoTime()
 			f()

--- a/tile-generation/src/test/scala/com/oculusinfo/tilegen/tiling/RDDBinnerTests.scala
+++ b/tile-generation/src/test/scala/com/oculusinfo/tilegen/tiling/RDDBinnerTests.scala
@@ -257,13 +257,9 @@ class RDDBinnerTestSuite extends FunSuite with SharedSparkContext with TileAsser
 		val oldTime2 = time(() => oldBinner.processDataByLevel(data, index, analytic, tileAnalytics, dataAnalytics, pyramid, levels).count)
 
 		val newTime1 = time(() => newBinner.processDataByLevel(data, index, analytic, tileAnalytics, dataAnalytics, pyramid, levels).count)
-		val results1 = newBinner.stats.map{case (stat, value) => "\t"+stat+": "+value.value}.mkString("\n")
 		val newTime2 = time(() => newBinner.processDataByLevel(data, index, analytic, tileAnalytics, dataAnalytics, pyramid, levels).count)
-		val results2 = newBinner.stats.map{case (stat, value) => "\t"+stat+": "+value.value}.mkString("\n")
 		val newTime3 = time(() => newBinner.processDataByLevel(data, index, analytic, tileAnalytics, dataAnalytics, pyramid, levels).count)
-		val results3 = newBinner.stats.map{case (stat, value) => "\t"+stat+": "+value.value}.mkString("\n")
 		val newTime4 = time(() => newBinner.processDataByLevel(data, index, analytic, tileAnalytics, dataAnalytics, pyramid, levels).count)
-		val results4 = newBinner.stats.map{case (stat, value) => "\t"+stat+": "+value.value}.mkString("\n")
 
 		val oldTime3 = time(() => oldBinner.processDataByLevel(data, index, analytic, tileAnalytics, dataAnalytics, pyramid, levels).count)
 		val oldTime4 = time(() => oldBinner.processDataByLevel(data, index, analytic, tileAnalytics, dataAnalytics, pyramid, levels).count)
@@ -274,12 +270,8 @@ class RDDBinnerTestSuite extends FunSuite with SharedSparkContext with TileAsser
 		println("Old time 4: "+oldTime4)
 		println
 		println("New time 1: "+newTime1)
-		println(results1)
 		println("New time 2: "+newTime2)
-		println(results2)
 		println("New time 3: "+newTime3)
-		println(results3)
 		println("New time 4: "+newTime4)
-		println(results4)
 	}
 }


### PR DESCRIPTION
Use mutable rather than immutable maps for merging of tile results from different records or workers.