### PR TITLE
Serialization Framework specification

### DIFF
--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/DefaultTileSerializerFactoryProvider.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/DefaultTileSerializerFactoryProvider.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (c) 2014 Oculus Info Inc. http://www.oculusinfo.com/
- * 
+ *
  * Released under the MIT License.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -31,15 +31,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.oculusinfo.binning.io.serialization.impl.DoubleJsonSerializerFactory;
-import com.oculusinfo.binning.io.serialization.impl.KryoSerializerFactory;
-import com.oculusinfo.binning.io.serialization.impl.PairArrayAvroSerializerFactory;
-import com.oculusinfo.binning.io.serialization.impl.PairAvroSerializerFactory;
-import com.oculusinfo.binning.io.serialization.impl.PrimitiveArrayAvroSerializerFactory;
-import com.oculusinfo.binning.io.serialization.impl.PrimitiveAvroSerializer;
-import com.oculusinfo.binning.io.serialization.impl.PrimitiveAvroSerializerFactory;
-import com.oculusinfo.binning.io.serialization.impl.StringIntPairArrayJsonSerializerFactory;
-import com.oculusinfo.binning.io.serialization.impl.StringLongPairArrayMapJsonSerializerFactory;
+import com.oculusinfo.binning.io.serialization.impl.*;
 import com.oculusinfo.binning.util.TypeDescriptor;
 import com.oculusinfo.factory.ConfigurableFactory;
 import com.oculusinfo.factory.providers.AbstractFactoryProvider;
@@ -52,10 +44,10 @@ import com.oculusinfo.factory.util.Pair;
  * <br>
  * To create one use the create method for the desired type. Example:<br>
  *
- * This isn't really an enum, but acts like one in all ways except 
- * initialization; it is not one to allow us to use loops and generification 
+ * This isn't really an enum, but acts like one in all ways except
+ * initialization; it is not one to allow us to use loops and generification
  * during initialization.
- * 
+ *
  * <pre>
  * <code>
  * DefaultPyramidIOFactoryProvider.FILE.create();
@@ -204,14 +196,9 @@ public final class DefaultTileSerializerFactoryProvider
 
 				{
 					List<Pair<String, TypeDescriptor>> primitives = new ArrayList<>();
-					primitives.add(new Pair<String, TypeDescriptor>("boolean", new TypeDescriptor(Boolean.class)));
-					primitives.add(new Pair<String, TypeDescriptor>("byte",    new TypeDescriptor(Byte.class)));
-					primitives.add(new Pair<String, TypeDescriptor>("short",   new TypeDescriptor(Short.class)));
-					primitives.add(new Pair<String, TypeDescriptor>("int",     new TypeDescriptor(Integer.class)));
-					primitives.add(new Pair<String, TypeDescriptor>("long",    new TypeDescriptor(Long.class)));
-					primitives.add(new Pair<String, TypeDescriptor>("float",   new TypeDescriptor(Float.class)));
-					primitives.add(new Pair<String, TypeDescriptor>("double",  new TypeDescriptor(Double.class)));
-					primitives.add(new Pair<String, TypeDescriptor>("string",  new TypeDescriptor(String.class)));
+					for (Class<?> primitive: KryoSerializer.PRIMITIVE_TYPES) {
+						primitives.add(new Pair<String, TypeDescriptor>(primitive.getSimpleName().toLowerCase(), new TypeDescriptor(primitive)));
+					}
 
 					// Simple types
 					for (final Pair<String, TypeDescriptor> primitive: primitives) {
@@ -253,7 +240,7 @@ public final class DefaultTileSerializerFactoryProvider
 				}
 			});
 
-	
+
 	// -------------------------------------
 
 	private final String      _name;

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/impl/KryoSerializer.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/impl/KryoSerializer.java
@@ -3,6 +3,8 @@ package com.oculusinfo.binning.io.serialization.impl;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.*;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.InflaterInputStream;
 
@@ -26,7 +28,7 @@ import com.oculusinfo.factory.util.Pair;
 
 /**
  * A generic Kryo serializer capable of serializing all sorts of tile data.
- * 
+ *
  * @author nkronenfeld
  *
  * @param <T> The type of data this instance of the serializer intends to serialize.
@@ -34,6 +36,15 @@ import com.oculusinfo.factory.util.Pair;
 public class KryoSerializer<T> implements TileSerializer<T> {
 	private static final long serialVersionUID = 611839716702420914L;
 	public static enum Codec {DEFLATE, BZIP, GZIP};
+	public static final Set<Class<?>> PRIMITIVE_TYPES =
+		Collections.unmodifiableSet(new HashSet<Class<?>>() {
+			private static final long serialVersionUID = 1L;
+
+			{
+				addAll(PrimitiveAvroSerializer.PRIMITIVE_TYPES);
+				add(Short.class);
+			}
+		});
 
 
 
@@ -44,10 +55,10 @@ public class KryoSerializer<T> implements TileSerializer<T> {
 	// Our type description
 	private TypeDescriptor _typeDesc;
 	private Codec _codec;
-	
+
 	/**
 	 * Create a serializer.
-	 * 
+	 *
 	 * @param typeDesc
 	 *            A detailed description of our fully expanded generic type.
 	 *            This should, of course, match the generic type with which the
@@ -94,7 +105,7 @@ public class KryoSerializer<T> implements TileSerializer<T> {
 		}
 		Input input = new Input(compressionStream);
 		try {
-	
+
 			Object data = kryo().readClassAndObject(input);
 			if (data instanceof TileData) return (TileData) data;
 			else return null;
@@ -132,8 +143,8 @@ public class KryoSerializer<T> implements TileSerializer<T> {
 		}
 	}
 
-    
-    
+
+
 	private class LocalizedKryo extends ThreadLocal<Kryo> {
 		protected Kryo initialValue () {
 			Kryo kryo = new Kryo();
@@ -169,14 +180,14 @@ public class KryoSerializer<T> implements TileSerializer<T> {
 	}
 
 	/**
-	 * This is just a quick wrapping InputStream to get around a bug in apache commons bzip 
-	 * uncompression, where when it is passed a buffer into which to read, and told to offset by 
-	 * the length of the buffer, it returns that the file is done, rather than that the buffer is 
+	 * This is just a quick wrapping InputStream to get around a bug in apache commons bzip
+	 * uncompression, where when it is passed a buffer into which to read, and told to offset by
+	 * the length of the buffer, it returns that the file is done, rather than that the buffer is
 	 * done.
-	 * 
+	 *
 	 * The bug is Commons Compress / COMPRESS-300
 	 * (https://issues.apache.org/jira/browse/COMPRESS-309)
-	 * 
+	 *
 	 * @author nkronenfeld
 	 */
 	public static class BZipInputStreamWrapper extends InputStream {

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/impl/KryoSerializerFactory.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/impl/KryoSerializerFactory.java
@@ -71,19 +71,6 @@ public class KryoSerializerFactory<T> extends ConfigurableFactory<TileSerializer
 
 
 	// Get the name to associate with a given value type
-	private static final Map<Class<?>, String> TYPE_NAMES =
-		Collections.unmodifiableMap(new HashMap<Class<?>, String>() {
-				private static final long serialVersionUID = 1L;
-				{
-					put(Boolean.class, "boolean");
-					put(Integer.class, "int");
-					put(Long.class, "long");
-					put(Float.class, "float");
-					put(Double.class, "double");
-					put(ByteBuffer.class, "bytes");
-					put(String.class, "string");
-				}
-			});
 	private static String getTypeName (TypeDescriptor type) {
 		Class<?> mainType = type.getMainType();
 		String name;
@@ -102,8 +89,7 @@ public class KryoSerializerFactory<T> extends ConfigurableFactory<TileSerializer
 			endSubList = ")";
 		} else {
 			// Normal case: name + generics
-			if (TYPE_NAMES.containsKey(mainType)) name = TYPE_NAMES.get(mainType);
-			else name = mainType.getSimpleName().toLowerCase();
+			name = mainType.getSimpleName().toLowerCase();
 			startSubList = "<";
 			endSubList = ">";
 		}

--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/datasets/TilingTask.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/datasets/TilingTask.scala
@@ -216,6 +216,9 @@ abstract class TilingTask[PT: ClassTag, DT: ClassTag, AT: ClassTag, BT]
 	/** Get the maximum number of bins to draw on the ends of segments, for line tiling */
 	def getMaximumLeaderLength = config.maximumLeaderLength
 
+	/** Get the maximum number of bins to draw on the ends of segments, disallowing the ability not to specify. */
+	def getDefiniteMaximumLeaderLength = config.getDefiniteMaximumLeaderLength
+
 	/** Get whether or not segments should be drawn as arcs */
 	def drawArcs = config.drawArcs
 
@@ -303,13 +306,13 @@ abstract class TilingTask[PT: ClassTag, DT: ClassTag, AT: ClassTag, BT]
 						                                                  getMinimumSegmentLength, getMaximumLeaderLength,
 						                                                  getNumXBins, getNumYBins)
 						else StandardBinningFunctions.locateLineLeaders(getIndexScheme, getTilePyramid, levels,
-						                                                getMinimumSegmentLength, getMaximumLeaderLength.get,
+						                                                getMinimumSegmentLength, getDefiniteMaximumLeaderLength,
 						                                                getNumXBins, getNumYBins)
 
 					val populateFcn: (TileIndex, Array[BinIndex], PT) => MutableMap[BinIndex, PT] =
 						if (drawArcs) StandardBinningFunctions.populateTileWithArcs(getMaximumLeaderLength,
 						                                                            StandardScalingFunctions.identityScale)
-						else StandardBinningFunctions.populateTileWithLineLeaders(getMaximumLeaderLength.get,
+						else StandardBinningFunctions.populateTileWithLineLeaders(getDefiniteMaximumLeaderLength,
 						                                                          StandardScalingFunctions.identityScale)
 
 					val tiles = binner.processData[Seq[Any], PT, AT, DT, BT](rdd, getBinningAnalytic, tileAnalytics, dataAnalytics,

--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/datasets/TilingTaskParameters.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/datasets/TilingTaskParameters.scala
@@ -62,6 +62,7 @@ case class TilingTaskParameters (name: String,
                                  maximumLeaderLength: Option[Int] = None,
                                  drawArcs: Boolean = false)
 {
+	def getDefiniteMaximumLeaderLength: Int = maximumLeaderLength.getOrElse(TilingTaskParametersFactory.MAXIMUM_LEADER_LENGTH.getDefaultValue)
 }
 
 

--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/datasets/ValueExtractor.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/datasets/ValueExtractor.scala
@@ -26,7 +26,6 @@
 package com.oculusinfo.tilegen.datasets
 
 
-
 import java.util.Arrays
 import java.lang.{Integer => JavaInt}
 import java.lang.{Long => JavaLong}
@@ -98,6 +97,8 @@ abstract class ValueExtractor[PT: ClassTag, BT] extends Serializable {
  * General constructors and properties for default value extractor factories
  */
 object ValueExtractorFactory {
+	val SERIALIZATION_FRAMEWORK = new StringProperty("framework", "The serialization framework to use by default when no specific serializer is mandated.", "avro",
+		Array("avro", "kryo"))
 	private[datasets] val FIELD_PROPERTY =
 		new StringProperty("field", "The field used by this value extractor", "INVALID FIELD")
 	private[datasets] val FIELDS_PROPERTY =
@@ -193,10 +194,13 @@ abstract class ValueExtractorFactory (name: String, parent: ConfigurableFactory[
 		extends NumericallyConfigurableFactory[ValueExtractor[_,_]](name, classOf[ValueExtractor[_,_]], parent, path)
 		with OptionsFactoryMixin[ValueExtractor[_, _]]
 {
+	import ValueExtractorFactory._
+
 	protected val serializerFactory: ConfigurableFactory[TileSerializer[_]] = {
 		val path = List("serializer").asJava
 		new TileSerializerFactory(this, path, DefaultTileSerializerFactoryProvider.values.map(_.createFactory(this, path)).toList.asJava)
 	}
+	addProperty(SERIALIZATION_FRAMEWORK, Arrays.asList("serialization"))
 	addChildFactory(serializerFactory)
 
 	/**
@@ -219,7 +223,11 @@ abstract class ValueExtractorFactory (name: String, parent: ConfigurableFactory[
 	}
 
 	def getDefaultSerializerType (baseType: String, expectedPrimitiveCLass: Class[_]*): String = {
-		baseType.format(expectedPrimitiveCLass.map(_.getSimpleName.toLowerCase()):_*)
+		val framework = getPropertyValue(SERIALIZATION_FRAMEWORK).toLowerCase()
+		val suffix = if ("avro" == framework) "-a"
+		else if ("kryo" == framework) "-k"
+		else ""
+		baseType.format(expectedPrimitiveCLass.map(_.getSimpleName.toLowerCase()):_*) + suffix
 	}
 }
 
@@ -238,7 +246,7 @@ class CountValueExtractorFactory (parent: ConfigurableFactory[_], path: JavaList
 	override protected def typedCreate[T, JT] (tag: ClassTag[T],
 	                                           numeric: ExtendedNumeric[T],
 	                                           conversion: TypeConversion[T, JT]): ValueExtractor[_, _] = {
-		serializerFactory.setDefaultValue(UberFactory.FACTORY_TYPE, getDefaultSerializerType("%s-a", conversion.toClass))
+		serializerFactory.setDefaultValue(UberFactory.FACTORY_TYPE, getDefaultSerializerType("%s", conversion.toClass))
 		val serializer: TileSerializer[JT] = checkBinClass(produce(classOf[TileSerializer[_]]), conversion.toClass, new TypeDescriptor(conversion.toClass))
 		new CountValueExtractor[T, JT](serializer)(tag, numeric, conversion)
 	}
@@ -291,18 +299,18 @@ class FieldValueExtractorFactory (parent: ConfigurableFactory[_], path: JavaList
 		val analytic = produce(classOf[BinningAnalytic[T, JT]])
 
 		if (analytic.isInstanceOf[NumericMeanBinningAnalytic[_]]) {
-			serializerFactory.setDefaultValue(UberFactory.FACTORY_TYPE, getDefaultSerializerType("%s-a", classOf[JavaDouble]))
+			serializerFactory.setDefaultValue(UberFactory.FACTORY_TYPE, getDefaultSerializerType("%s", classOf[JavaDouble]))
 			val serializer = checkBinClass(produce(classOf[TileSerializer[_]]), classOf[JavaDouble], new TypeDescriptor(classOf[JavaDouble]))
 			new MeanValueExtractor[T](field, analytic.asInstanceOf[NumericMeanBinningAnalytic[T]], serializer)(tag, numeric)
 		} else if (analytic.isInstanceOf[NumericStatsBinningAnalytic[_]]) {
-			serializerFactory.setDefaultValue(UberFactory.FACTORY_TYPE, getDefaultSerializerType("(%s, %s)-a", classOf[JavaDouble], classOf[JavaDouble]))
+			serializerFactory.setDefaultValue(UberFactory.FACTORY_TYPE, getDefaultSerializerType("(%s, %s)", classOf[JavaDouble], classOf[JavaDouble]))
 			val serializer = checkBinClass(produce(classOf[TileSerializer[_]]),
 			                               classOf[Pair[JavaDouble, JavaDouble]], new TypeDescriptor(classOf[Pair[JavaDouble, JavaDouble]],
 			                                                                                         new TypeDescriptor(classOf[JavaDouble]),
 			                                                                                         new TypeDescriptor(classOf[JavaDouble])))
 			new StatsValueExtractor[T](field, analytic.asInstanceOf[NumericStatsBinningAnalytic[T]], serializer)(tag, numeric)
 		} else {
-			serializerFactory.setDefaultValue(UberFactory.FACTORY_TYPE, getDefaultSerializerType("%s-a", conversion.toClass))
+			serializerFactory.setDefaultValue(UberFactory.FACTORY_TYPE, getDefaultSerializerType("%s", conversion.toClass))
 			val serializer = checkBinClass(produce(classOf[TileSerializer[_]]), conversion.toClass, new TypeDescriptor(conversion.toClass))
 			new FieldValueExtractor[T, JT](field, analytic, serializer)(tag, numeric, conversion)
 		}
@@ -404,7 +412,7 @@ class SeriesValueExtractorFactory (parent: ConfigurableFactory[_], path: JavaLis
 	                                           conversion: TypeConversion[T, JT]): ValueExtractor[_, _] = {
 		val fields = getPropertyValue(ValueExtractorFactory.FIELDS_PROPERTY).asScala.toArray
 		val elementAnalytic = produce(classOf[BinningAnalytic[T, JT]])
-		serializerFactory.setDefaultValue(UberFactory.FACTORY_TYPE, getDefaultSerializerType("[%s]-a", conversion.toClass))
+		serializerFactory.setDefaultValue(UberFactory.FACTORY_TYPE, getDefaultSerializerType("[%s]", conversion.toClass))
 		val serializer = checkBinClass(produce(classOf[TileSerializer[_]]), classOf[JavaList[JT]],
 		                               new TypeDescriptor(classOf[JavaList[JT]], new TypeDescriptor(conversion.toClass)))
 		new SeriesValueExtractor[T, JT](fields, elementAnalytic, serializer)(tag, numeric, conversion)
@@ -481,7 +489,7 @@ class IndirectSeriesValueExtractorFactory (parent: ConfigurableFactory[_], path:
 		val valueField = getPropertyValue(VALUE_PROPERTY)
 		val validKeys = getPropertyValue(VALID_KEYS_PROPERTY).asScala.toArray
 		val elementAnalytic = produce(classOf[BinningAnalytic[T, JT]])
-		serializerFactory.setDefaultValue(UberFactory.FACTORY_TYPE, getDefaultSerializerType("[%s]-a", conversion.toClass))
+		serializerFactory.setDefaultValue(UberFactory.FACTORY_TYPE, getDefaultSerializerType("[%s]", conversion.toClass))
 		val serializer = checkBinClass(produce(classOf[TileSerializer[_]]), classOf[JavaList[JT]],
 		                               new TypeDescriptor(classOf[JavaList[JT]], new TypeDescriptor(conversion.toClass)))
 
@@ -547,7 +555,7 @@ class MultiFieldValueExtractorFactory (parent: ConfigurableFactory[_], path: Jav
 	                                           conversion: TypeConversion[T, JT]): ValueExtractor[_, _] = {
 		val fields = getPropertyValue(ValueExtractorFactory.FIELDS_PROPERTY).asScala.toArray
 		val analytic = produce(classOf[BinningAnalytic[T, JT]])
-		serializerFactory.setDefaultValue(UberFactory.FACTORY_TYPE, getDefaultSerializerType("[(%s, %s)]-a", classOf[String], conversion.toClass))
+		serializerFactory.setDefaultValue(UberFactory.FACTORY_TYPE, getDefaultSerializerType("[(%s, %s)]", classOf[String], conversion.toClass))
 		val serializer = checkBinClass(produce(classOf[TileSerializer[_]]),
 		                               classOf[JavaList[Pair[String, JT]]],
 		                               new TypeDescriptor(classOf[JavaList[Pair[String, JT]]],
@@ -656,7 +664,7 @@ class StringValueExtractorFactory (parent: ConfigurableFactory[_], path: JavaLis
 	                                           conversion: TypeConversion[T, JT]): ValueExtractor[_, _] = {
 		val field = getPropertyValue(ValueExtractorFactory.FIELD_PROPERTY)
 		val binningAnalytic = StringScoreBinningAnalyticFactory.getBinningAnalytic[T, JT](this)(numeric, conversion)
-		serializerFactory.setDefaultValue(UberFactory.FACTORY_TYPE, getDefaultSerializerType("[(%s, %s)]-a", classOf[String], conversion.toClass))
+		serializerFactory.setDefaultValue(UberFactory.FACTORY_TYPE, getDefaultSerializerType("[(%s, %s)]", classOf[String], conversion.toClass))
 		val serializer = checkBinClass(produce(classOf[TileSerializer[_]]),
 		                               classOf[JavaList[Pair[String, JT]]],
 		                               new TypeDescriptor(classOf[JavaList[Pair[String, JT]]],
@@ -736,7 +744,7 @@ class SubstringValueExtractorFactory (parent: ConfigurableFactory[_], path: Java
 			(p.getFirst.intValue, p.getSecond.intValue)
 		)
 		val binningAnalytic = StringScoreBinningAnalyticFactory.getBinningAnalytic[T, JT](this)(numeric, conversion)
-		serializerFactory.setDefaultValue(UberFactory.FACTORY_TYPE, getDefaultSerializerType("[(%s, %s)]-a", classOf[String], conversion.toClass))
+		serializerFactory.setDefaultValue(UberFactory.FACTORY_TYPE, getDefaultSerializerType("[(%s, %s)]", classOf[String], conversion.toClass))
 		val serializer = checkBinClass(produce(classOf[TileSerializer[_]]),
 		                               classOf[JavaList[Pair[String, JT]]],
 		                               new TypeDescriptor(classOf[JavaList[Pair[String, JT]]],

--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/datasets/ValueExtractor.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/datasets/ValueExtractor.scala
@@ -200,7 +200,7 @@ abstract class ValueExtractorFactory (name: String, parent: ConfigurableFactory[
 		val path = List("serializer").asJava
 		new TileSerializerFactory(this, path, DefaultTileSerializerFactoryProvider.values.map(_.createFactory(this, path)).toList.asJava)
 	}
-	addProperty(SERIALIZATION_FRAMEWORK, Arrays.asList("serialization"))
+	addProperty(SERIALIZATION_FRAMEWORK, Arrays.asList("serializer"))
 	addChildFactory(serializerFactory)
 
 	/**


### PR DESCRIPTION
I've changed the way default serializers are determined so that one can set the serialization framework (avro or kryo) without specifying anything else, and everything else will get defaulted.

Default framework is avro, so defaults won't change anything.