### PR TITLE
Fixed bucket transformer indexing error

### DIFF
--- a/binning-utilities/src/main/java/com/oculusinfo/binning/impl/AverageTileBucketView.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/impl/AverageTileBucketView.java
@@ -43,10 +43,9 @@ import com.oculusinfo.binning.TileIndex;
 public class AverageTileBucketView<T extends Number> implements TileData<List<T>> {
 	private static final long serialVersionUID = 1234567890L;
 
-	private TileData<List<T>> _base 		= null;
-
-	private Integer			  _startCompare = null;
-	private Integer			  _endCompare 	= null;
+	private TileData<List<T>> _base = null;
+	private Integer	_startCompare = null;
+	private Integer	_endCompare = null;
 
 
 	public AverageTileBucketView (TileData<List<T>> base, int startComp, int endComp) {
@@ -54,6 +53,7 @@ public class AverageTileBucketView<T extends Number> implements TileData<List<T>
 		_startCompare = startComp;
 		_endCompare = endComp;
 	}
+
 
 	@Override
 	public TileIndex getDefinition () {
@@ -75,7 +75,7 @@ public class AverageTileBucketView<T extends Number> implements TileData<List<T>
 		List<T> binContents = _base.getBin(x, y);
 		int binSize = binContents.size();
 		int start = ( _startCompare != null ) ? _startCompare : 0;
-		int end = ( _endCompare != null && _endCompare < binSize && _endCompare != 0) ? _endCompare : binSize;
+		int end = ( _endCompare != null && _endCompare < binSize ) ? _endCompare : binSize;
 
 		double total = 0;
 		int count = 0;

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/impl/DeltaTileBucketView.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/impl/DeltaTileBucketView.java
@@ -42,11 +42,11 @@ import com.oculusinfo.binning.util.BinaryOperator;
 public class DeltaTileBucketView<T> implements TileData<List<T>> {
 	private static final long serialVersionUID = 1234567890L;
 
-	private TileData<List<T>> _base 		= null;
-	private TileData<List<T>> _delta		= null;
-	private BinaryOperator _operator 	= null;
-	private Integer			  _startCompare = null;
-	private Integer			  _endCompare 	= null;
+	private TileData<List<T>> _base = null;
+	private TileData<List<T>> _delta = null;
+	private BinaryOperator _operator = null;
+	private Integer	_startCompare = null;
+	private Integer	_endCompare = null;
 
 
 	public DeltaTileBucketView (TileData<List<T>> base, TileData<List<T>> delta, BinaryOperator.OPERATOR_TYPE op,
@@ -100,7 +100,7 @@ public class DeltaTileBucketView<T> implements TileData<List<T>> {
 
 		int binSize = sourceData.size();
 		int start = ( _startCompare != null ) ? _startCompare : 0;
-		int end = ( _endCompare != null && _endCompare < binSize && _endCompare != 0) ? _endCompare : binSize;
+		int end = ( _endCompare != null && _endCompare < binSize ) ? _endCompare : binSize;
 
 		for(int i = 0; i < binSize; i++) {
 			if ( i >= start && i <= end ) {

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/impl/FilterTileBucketView.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/impl/FilterTileBucketView.java
@@ -41,9 +41,9 @@ import com.oculusinfo.binning.TileIndex;
 public class FilterTileBucketView<T> implements TileData<List<T>> {
 	private static final long serialVersionUID = 1234567890L;
 
-	private TileData<List<T>> _base 		= null;
-	private Integer			  _startBucket 	= null;
-	private Integer			  _endBucket 	= null;
+	private TileData<List<T>> _base = null;
+	private Integer	_startBucket = null;
+	private Integer	_endBucket = null;
 
 
 	public FilterTileBucketView (TileData<List<T>> base, Integer startBucket, Integer endBucket) {
@@ -88,7 +88,7 @@ public class FilterTileBucketView<T> implements TileData<List<T>> {
 		List<T> binContents = _base.getBin(x, y);
 		int binSize = binContents.size();
 		int start = ( _startBucket != null ) ? _startBucket : 0;
-		int end = ( _endBucket != null && _endBucket < binSize && _endBucket != 0) ? _endBucket : binSize;
+		int end = ( _endBucket != null && _endBucket < binSize ) ? _endBucket : binSize;
 
 		for(int i = 0; i < binSize; i++) {
 			if ( i >= start && i <= end ) {

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/AvgDivBucketTileTransformer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/AvgDivBucketTileTransformer.java
@@ -52,16 +52,16 @@ import org.json.JSONObject;
 public class AvgDivBucketTileTransformer<T extends Number> implements TileTransformer<List<T>> {
 	private static final Logger LOGGER = LoggerFactory.getLogger( AvgDivBucketTileTransformer.class );
 
-	protected Integer _averageRange 	= 0;
-	protected Integer _startBucket 	= 0;
-	protected Integer _endBucket 		= 0;
+	protected Integer _averageRange = 0;
+	protected Integer _startBucket = 0;
+	protected Integer _endBucket = 0;
 
 	public AvgDivBucketTileTransformer(JSONObject arguments){
 		if ( arguments != null ) {
 			// get the start and end time range
-			_averageRange 	= arguments.optInt("averageRange");
-			_startBucket 	= arguments.optInt("startBucket");
-			_endBucket 		= arguments.optInt("endBucket");
+			_averageRange = arguments.optInt("averageRange");
+			_startBucket = arguments.optInt("startBucket");
+			_endBucket = arguments.optInt("endBucket");
 		} else {
 			LOGGER.warn("No arguments passed in to filterbucket transformer");
 		}

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/BucketTileTransformer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/BucketTileTransformer.java
@@ -44,8 +44,8 @@ public abstract class BucketTileTransformer<T> implements TileTransformer<List<T
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(BucketTileTransformer.class);
 
-	protected Integer _startBucket = 0;
-	protected Integer _endBucket = 0;
+	protected Integer _startBucket = null;
+	protected Integer _endBucket = null;
 
 	private List<Double> _minVals = null;
 	private List<Double> _maxVals = null;
@@ -53,8 +53,8 @@ public abstract class BucketTileTransformer<T> implements TileTransformer<List<T
 	public BucketTileTransformer(JSONObject arguments){
 		if ( arguments != null ) {
 			// get the start and end time range
-			_startBucket 	= arguments.optInt("startBucket");
-			_endBucket 		= arguments.optInt("endBucket");
+			_startBucket = arguments.optInt("startBucket");
+			_endBucket = arguments.optInt("endBucket");
 		} else {
 			LOGGER.warn("No arguments passed in to transformer " + getClass().getSimpleName());
 		}


### PR DESCRIPTION
There was an error causing a startBucket = 0 and endBucket = 0 to return all buckets rather than the first.