### PR TITLE
Client now handles empty (null) buckets

### DIFF
--- a/tile-client/src/js/layer/renderer/aggregator/TopicCountAggregator.js
+++ b/tile-client/src/js/layer/renderer/aggregator/TopicCountAggregator.js
@@ -52,8 +52,10 @@
         for ( i=0; i<buckets.length; i++ ) {
             // add to total count
             score = buckets[i].score;
-            total = ( typeof score === "number" ) ? score : score.total;
-            aggregation.count += total;
+            if (score !== undefined) {
+                total = ( typeof score === "number" ) ? score : score.total;
+                aggregation.count += total;
+            }
         }
         return aggregation;
     }


### PR DESCRIPTION
Bucketed tiles that have empty (null) buckets are now ignored when aggregating client side.