### PR TITLE
Fix JSON tile visualizer

### DIFF
--- a/binning-utilities/src/main/java/com/oculusinfo/binning/visualization/JsonTileVisualizer.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/visualization/JsonTileVisualizer.java
@@ -387,7 +387,6 @@ public class JsonTileVisualizer extends JFrame {
 
 
 	private void showCurrentTile () {
-		if (null == _pyramid) return;
 		if (null == _pyramidId) return;
 		if (null == _pyramidIO) return;
 		if (null == _levelField.getSelectedItem()) return;


### PR DESCRIPTION
The JSON visualizer doesn't need an accurate pyramid; it now won't refuse to show tiles just because pyramid metadata it doesn't need is incorrect.