### PR TITLE
Multi column hbase

### DIFF
--- a/binning-utilities/src/main/java/com/oculusinfo/binning/impl/DenseTileMultiSliceView.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/impl/DenseTileMultiSliceView.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2014 Oculus Info Inc. http://www.oculusinfo.com/
+ *
+ * Released under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.oculusinfo.binning.impl;
+
+import com.oculusinfo.binning.TileData;
+import com.oculusinfo.binning.TileIndex;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This implementation of TileData takes a TileData whose bins are lists of buckets, and presents
+ * a view to a single slice of it - the same bucket in each bin.
+ *
+ * @author nkronenfeld
+ */
+public class DenseTileMultiSliceView<T> implements TileData<List<T>> {
+	private TileData<List<T>> _base;
+	private List<Integer>     _slices;
+	public DenseTileMultiSliceView (TileData<List<T>> base, List<Integer> slices) {
+		_base = base;
+		_slices = Collections.unmodifiableList(new ArrayList<>(slices));
+	}
+	public DenseTileMultiSliceView (TileData<List<T>> base, int minSlice, int maxSlice) {
+		_base = base;
+		List<Integer> slices = new ArrayList<>();
+		for (int i=minSlice; i <= maxSlice; ++i) slices.add(i);
+		_slices = Collections.unmodifiableList(slices);
+	}
+
+	@Override
+	public TileIndex getDefinition() {
+		return _base.getDefinition();
+	}
+
+	@Override
+	public void setBin(int x, int y, List<T> value) {
+		assert(value.size() == _slices.size());
+		List<T> binOrig = _base.getBin(x, y);
+		try {
+			for (int i=0; i < _slices.size(); ++i) {
+				binOrig.set(_slices.get(i), value.get(i));
+			}
+		} catch (UnsupportedOperationException e) {
+			// List is probably unmodifiable; just create a new one then.
+			// Create a copy
+			List<T> newValue = new ArrayList<>(binOrig);
+			// Modify our values
+			for (int i=0; i < _slices.size(); ++i) {
+				newValue.set(_slices.get(i), value.get(i));
+			}
+			// Replace into the original
+			// Original was unmodifiable, make this unmodifiable too
+			_base.setBin(x, y, Collections.unmodifiableList(newValue));
+		} catch (NullPointerException e) {
+			// No original list; make one.
+			List<T> newValue = new ArrayList<>();
+			for (int i=0; i < _slices.size(); ++i) {
+				int slice = _slices.get(i);
+				while (newValue.size() <= slice) newValue.add(null);
+				newValue.set(slice, value.get(i));
+			}
+			_base.setBin(x, y, newValue);
+		}
+	}
+
+	@Override
+	public List<T> getBin(int x, int y) {
+		List<T> origValue = _base.getBin(x, y);
+		if (null == origValue) return null;
+		List<T> result = new ArrayList<>(_slices.size());
+		for (int slice: _slices) {
+			if (origValue.size() <= slice) result.add(null);
+			else result.add(origValue.get(slice));
+		}
+		return result;
+	}
+
+	@Override
+	public Collection<String> getMetaDataProperties() {
+		return _base.getMetaDataProperties();
+	}
+
+	@Override
+	public String getMetaData(String property) {
+		return _base.getMetaData(property);
+	}
+
+	@Override
+	public void setMetaData(String property, Object value) {
+		_base.setMetaData(property, value);
+	}
+}

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/DefaultPyramidIOFactoryProvider.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/DefaultPyramidIOFactoryProvider.java
@@ -1,18 +1,18 @@
 /*
  * Copyright (c) 2014 Oculus Info Inc. http://www.oculusinfo.com/
- * 
+ *
  * Released under the MIT License.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -27,11 +27,7 @@ package com.oculusinfo.binning.io;
 
 import java.util.List;
 
-import com.oculusinfo.binning.io.impl.DummyPyramidIOFactory;
-import com.oculusinfo.binning.io.impl.HBasePyramidIOFactory;
-import com.oculusinfo.binning.io.impl.JDBCPyramidIOFactory;
-import com.oculusinfo.binning.io.impl.SQLitePyramidIOFactory;
-import com.oculusinfo.binning.io.impl.FileBasedPyramidIOFactory;
+import com.oculusinfo.binning.io.impl.*;
 import com.oculusinfo.factory.ConfigurableFactory;
 import com.oculusinfo.factory.providers.FactoryProvider;
 
@@ -42,13 +38,13 @@ import com.oculusinfo.factory.providers.FactoryProvider;
  * availables in the system.<br>
  * <br>
  * To create one use the create method for the desired type. Example:<br>
- * 
+ *
  * <pre>
  * <code>
  * DefaultPyramidIOFactoryProvider.FILE.create();
  * </code>
  * </pre>
- * 
+ *
  * @author cregnier
  */
 public enum DefaultPyramidIOFactoryProvider implements FactoryProvider<PyramidIO> {
@@ -56,6 +52,12 @@ public enum DefaultPyramidIOFactoryProvider implements FactoryProvider<PyramidIO
 			@Override
 			public ConfigurableFactory<PyramidIO> create(ConfigurableFactory<?> parent, java.util.List<String> path) {
 				return new HBasePyramidIOFactory(parent, path);
+			}
+		}),
+	HBASE_SLICED(new Constructor() {
+			@Override
+			public ConfigurableFactory<PyramidIO> create(ConfigurableFactory<?> parent, java.util.List<String> path) {
+				return new HBaseSlicedPyramidIOFactory(parent, path);
 			}
 		}),
     FILE(new Constructor() {

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/HBasePyramidIO.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/HBasePyramidIO.java
@@ -69,7 +69,7 @@ public class HBasePyramidIO implements PyramidIO {
 
 
 	private static final byte[]      EMPTY_BYTES          = new byte[0];
-	private static final byte[]      TILE_FAMILY_NAME     = "tileData".getBytes();
+	protected static final byte[]      TILE_FAMILY_NAME     = "tileData".getBytes();
 	public static final HBaseColumn  TILE_COLUMN          = new HBaseColumn(TILE_FAMILY_NAME, EMPTY_BYTES);
 	private static final byte[]      METADATA_FAMILY_NAME = "metaData".getBytes();
 	public static final HBaseColumn  METADATA_COLUMN      = new HBaseColumn(METADATA_FAMILY_NAME, EMPTY_BYTES);
@@ -160,7 +160,7 @@ public class HBasePyramidIO implements PyramidIO {
 	 * @return The put request - the same as is passed in, or a new request if
 	 *         none was passed in.
 	 */
-	private Put addToPut (Put existingPut, String rowId, HBaseColumn column, byte[] data) {
+	protected Put addToPut (Put existingPut, String rowId, HBaseColumn column, byte[] data) {
 		if (null == existingPut) {
 			existingPut = new Put(rowId.getBytes());
 		}
@@ -178,7 +178,7 @@ public class HBasePyramidIO implements PyramidIO {
 	 * @param rows
 	 *            The rows to write
 	 */
-	private void writeRows (String tableName, List<Row> rows) throws InterruptedException, IOException {
+	protected void writeRows (String tableName, List<Row> rows) throws InterruptedException, IOException {
 		Table table = getTable(tableName);
 		Object[] results = new Object[rows.size()];
 		table.batch(rows, results);
@@ -294,12 +294,18 @@ public class HBasePyramidIO implements PyramidIO {
 	public <T> List<TileData<T>> readTiles (String tableName,
 	                                        TileSerializer<T> serializer,
 	                                        Iterable<TileIndex> tiles) throws IOException {
+		return readTiles(tableName, serializer, tiles, TILE_COLUMN);
+	}
+	protected <T> List<TileData<T>> readTiles (String tableName,
+											   TileSerializer<T> serializer,
+											   Iterable<TileIndex> tiles,
+											   HBaseColumn column) throws IOException {
 		List<String> rowIds = new ArrayList<String>();
 		for (TileIndex tile: tiles) {
 			rowIds.add(rowIdFromTileIndex(tile));
 		}
 
-		List<Map<HBaseColumn, byte[]>> rawResults = readRows(tableName, rowIds, TILE_COLUMN);
+		List<Map<HBaseColumn, byte[]>> rawResults = readRows(tableName, rowIds, column);
 
 		List<TileData<T>> results = new LinkedList<TileData<T>>();
 
@@ -310,7 +316,7 @@ public class HBasePyramidIO implements PyramidIO {
 			Map<HBaseColumn, byte[]> rawResult = iData.next();
 			TileIndex index = indexIterator.next();
 			if (null != rawResult) {
-				byte[] rawData = rawResult.get(TILE_COLUMN);
+				byte[] rawData = rawResult.get(column);
 				ByteArrayInputStream bais = new ByteArrayInputStream(rawData);
 				TileData<T> data = serializer.deserialize(index, bais);
 				results.add(data);

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIO.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIO.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2014 Oculus Info Inc.
+ * http://www.oculusinfo.com/
+ *
+ * Released under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.oculusinfo.binning.io.impl;
+
+import com.oculusinfo.binning.TileData;
+import com.oculusinfo.binning.TileIndex;
+import com.oculusinfo.binning.impl.DenseTileMultiSliceView;
+import com.oculusinfo.binning.io.serialization.TileSerializer;
+import com.oculusinfo.binning.util.TypeDescriptor;
+import org.apache.hadoop.hbase.client.Row;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * This version of the HBasePyramidIO is specialized for bucketted tiles; it will take a tile whose bins are
+ * lists (of buckets) of something - doesn't matter what - and instead of storing the tile as a monolithic tile
+ * in the tileData column, as HBasePyramidIO does, it will store the contents in separate columns.
+ */
+public class HBaseSlicedPyramidIO extends HBasePyramidIO {
+	private static final Pattern SLICE_PATTERN = Pattern.compile("(?<table>.*)\\[(?<min>[0-9]+)(?>-(?<max>[0-9]+))?\\]");
+
+	public HBaseSlicedPyramidIO (String zookeeperQuorum, String zookeeperPort, String hbaseMaster)
+		throws IOException {
+		super(zookeeperQuorum, zookeeperPort, hbaseMaster);
+	}
+
+	private int numSlices (TileData<?> tile) {
+		int slices = 0;
+		TileIndex index = tile.getDefinition();
+		for (int x=0; x < index.getXBins(); ++x) {
+			for (int y = 0; y < index.getYBins(); ++y) {
+				try {
+					List<?> bin = (List<?>) tile.getBin(x, y);
+					int size = bin.size();
+					if (size > slices) slices = size;
+				} catch (ClassCastException|NullPointerException e) {
+					// Swallow it, we don't care here.
+				}
+			}
+		}
+		return slices;
+	}
+
+	@Override
+	public <T> void writeTiles(String tableName, TileSerializer<T> serializer, Iterable<TileData<T>> data) throws IOException {
+		TypeDescriptor binType = serializer.getBinTypeDescription();
+		if (List.class == binType.getMainType()) {
+			writeSlices(tableName, (TileSerializer) serializer, (Iterable) data);
+		} else {
+			super.writeTiles(tableName, serializer, data);
+		}
+	}
+
+	private HBaseColumn getSliceColumn (int minSlice, int maxSlice) {
+		String qualifier;
+		if (minSlice == maxSlice) {
+			qualifier = ""+minSlice;
+		} else {
+			qualifier = ""+minSlice+"-"+maxSlice;
+		}
+		return new HBaseColumn(TILE_FAMILY_NAME, qualifier.getBytes());
+	}
+
+	private <T> void writeSlices (String tableName,
+								  TileSerializer<List<T>> serializer,
+								  Iterable<TileData<List<T>>> data) throws IOException {
+		List<Row> rows = new ArrayList<Row>();
+		for (TileData<List<T>> tile: data) {
+			// Record our base form
+			{
+				ByteArrayOutputStream baos = new ByteArrayOutputStream();
+				serializer.serialize(tile, baos);
+
+				rows.add(addToPut(null, rowIdFromTileIndex(tile.getDefinition()),
+				                  TILE_COLUMN, baos.toByteArray()));
+			}
+			// Figure out into how many slices to divide the data
+			int slices = numSlices(tile);
+			// Make sure we have all our necessary columns.
+			// Divide the tile into slices, storing each of them individually in their own column
+			for (int s = 0; s < slices; ++s) {
+				TileData<List<T>> slice = new DenseTileMultiSliceView<T>(tile, s, s);
+				ByteArrayOutputStream baos = new ByteArrayOutputStream();
+				serializer.serialize(slice, baos);
+				rows.add(addToPut(null, rowIdFromTileIndex(tile.getDefinition()),
+				                  getSliceColumn(s, s), baos.toByteArray()));
+			}
+		}
+		try {
+			writeRows(tableName, rows);
+		} catch (InterruptedException e) {
+			throw new IOException("Error writing tiles to HBase", e);
+		}
+	}
+
+	@Override
+	public <T> List<TileData<T>> readTiles (String tableName,
+											TileSerializer<T> serializer,
+											Iterable<TileIndex> tiles) throws IOException {
+		Matcher m = SLICE_PATTERN.matcher(tableName);
+		if (m.matches()) {
+			String realName = m.group("table");
+			HBaseColumn c;
+			int min = Integer.parseInt(m.group("min"));
+			if (null == m.group("max")) {
+				c = getSliceColumn(min, min);
+			} else {
+				int max = Integer.parseInt(m.group("max"));
+				c = getSliceColumn(min, max);
+			}
+			return super.readTiles(realName, serializer, tiles, c);
+		} else {
+			return super.readTiles(tableName, serializer, tiles);
+		}
+	}
+}

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIOFactory.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIOFactory.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2014 Oculus Info Inc.
+ * http://www.oculusinfo.com/
+ *
+ * Released under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.oculusinfo.binning.io.impl;
+
+import com.oculusinfo.binning.io.PyramidIO;
+import com.oculusinfo.factory.ConfigurableFactory;
+import com.oculusinfo.factory.SharedInstanceFactory;
+import com.oculusinfo.factory.properties.StringProperty;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class HBaseSlicedPyramidIOFactory extends SharedInstanceFactory<PyramidIO> {
+	private static final Logger LOGGER = LoggerFactory.getLogger(HBasePyramidIOFactory.class);
+
+
+	public HBaseSlicedPyramidIOFactory(ConfigurableFactory<?> parent, List<String> path) {
+		super("hbase-sliced", PyramidIO.class, parent, path);
+
+		addProperty(HBasePyramidIOFactory.HBASE_ZOOKEEPER_QUORUM);
+		addProperty(HBasePyramidIOFactory.HBASE_ZOKEEPER_PORT);
+		addProperty(HBasePyramidIOFactory.HBASE_MASTER);
+	}
+
+	@Override
+	protected PyramidIO createInstance () {
+		try {
+			String quorum = getPropertyValue(HBasePyramidIOFactory.HBASE_ZOOKEEPER_QUORUM);
+			String port = getPropertyValue(HBasePyramidIOFactory.HBASE_ZOKEEPER_PORT);
+			String master = getPropertyValue(HBasePyramidIOFactory.HBASE_MASTER);
+			return new HBaseSlicedPyramidIO(quorum, port, master);
+		}
+		catch (Exception e) {
+			LOGGER.error("Error trying to create HBaseSlicedPyramidIO", e);
+		}
+		return null;
+	}
+}
+

--- a/binning-utilities/src/test/java/com/oculusinfo/binning/MultiSliceViewTest.java
+++ b/binning-utilities/src/test/java/com/oculusinfo/binning/MultiSliceViewTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2014 Oculus Info Inc. http://www.oculusinfo.com/
+ *
+ * Released under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.oculusinfo.binning;
+
+import com.oculusinfo.binning.impl.DenseTileData;
+import com.oculusinfo.binning.impl.DenseTileMultiSliceView;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class MultiSliceViewTest {
+	@Test
+	public void testNullBinReplacement () {
+		TileData<List<Integer>> base = new DenseTileData<List<Integer>>(new TileIndex(0, 0, 0, 1, 1), (List<Integer>) null);
+		TileData<List<Integer>> slice = new DenseTileMultiSliceView<Integer>(base, Arrays.asList(2, 0));
+		slice.setBin(0, 0, Arrays.asList(4, 2));
+		Assert.assertEquals(2, base.getBin(0, 0).get(0).intValue());
+		Assert.assertNull(     base.getBin(0, 0).get(1));
+		Assert.assertEquals(4, base.getBin(0, 0).get(2).intValue());
+	}
+	@Test
+	public void testUnmodifiableBinReplacement () {
+		List<Integer> binVal = new ArrayList<>();
+		binVal.add(3);
+		binVal.add(4);
+		binVal.add(5);
+		TileData<List<Integer>> base = new DenseTileData<List<Integer>>(new TileIndex(0, 0, 0, 1, 1));
+		base.setBin(0, 0, Collections.unmodifiableList(binVal));
+		TileData<List<Integer>> slice = new DenseTileMultiSliceView<Integer>(base, Arrays.asList(2, 0));
+		slice.setBin(0, 0, Arrays.asList(6, 2));
+		Assert.assertEquals(2, base.getBin(0, 0).get(0).intValue());
+		Assert.assertEquals(4, base.getBin(0, 0).get(1).intValue());
+		Assert.assertEquals(6, base.getBin(0, 0).get(2).intValue());
+
+		Assert.assertEquals(3, binVal.get(0).intValue());
+		Assert.assertEquals(4, binVal.get(1).intValue());
+		Assert.assertEquals(5, binVal.get(2).intValue());
+	}
+
+	@Test
+	public void testModifiableBinReplacement () {
+		List<Integer> binVal = new ArrayList<>();
+		binVal.add(3);
+		binVal.add(4);
+		binVal.add(5);
+		TileData<List<Integer>> base = new DenseTileData<List<Integer>>(new TileIndex(0, 0, 0, 1, 1));
+		base.setBin(0, 0, binVal);
+		TileData<List<Integer>> slice = new DenseTileMultiSliceView<Integer>(base, Arrays.asList(2, 0));
+		slice.setBin(0, 0, Arrays.asList(6, 2));
+		Assert.assertEquals(2, base.getBin(0, 0).get(0).intValue());
+		Assert.assertEquals(4, base.getBin(0, 0).get(1).intValue());
+		Assert.assertEquals(6, base.getBin(0, 0).get(2).intValue());
+
+		Assert.assertEquals(2, binVal.get(0).intValue());
+		Assert.assertEquals(4, binVal.get(1).intValue());
+		Assert.assertEquals(6, binVal.get(2).intValue());
+	}
+
+	@Test
+	public void testBinRetrieval () {
+		TileData<List<Integer>> base = new DenseTileData(new TileIndex(0, 0, 0, 1, 1));
+		base.setBin(0, 0, Arrays.asList(-0, -1, -2, -3, -4, -5, -6, -7));
+		TileData<List<Integer>> slice1 = new DenseTileMultiSliceView<Integer>(base, Arrays.asList(1, 3, 5, 7));
+		TileData<List<Integer>> slice2 = new DenseTileMultiSliceView<Integer>(base, Arrays.asList(6, 4, 2, 0));
+
+		List<Integer> b1 = slice1.getBin(0, 0);
+		Assert.assertEquals(4, b1.size());
+		Assert.assertEquals(-1, b1.get(0).intValue());
+		Assert.assertEquals(-3, b1.get(1).intValue());
+		Assert.assertEquals(-5, b1.get(2).intValue());
+		Assert.assertEquals(-7, b1.get(3).intValue());
+
+		List<Integer> b2 = slice2.getBin(0, 0);
+		Assert.assertEquals(4, b2.size());
+		Assert.assertEquals(-6, b2.get(0).intValue());
+		Assert.assertEquals(-4, b2.get(1).intValue());
+		Assert.assertEquals(-2, b2.get(2).intValue());
+		Assert.assertEquals(-0, b2.get(3).intValue());
+	}
+}

--- a/binning-utilities/src/test/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIOTest.java
+++ b/binning-utilities/src/test/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIOTest.java
@@ -33,11 +33,13 @@ import com.oculusinfo.binning.io.serialization.impl.PrimitiveArrayAvroSerializer
 import com.oculusinfo.binning.util.TypeDescriptor;
 import org.apache.avro.file.CodecFactory;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.List;
 
+@Ignore
 public class HBaseSlicedPyramidIOTest {
 	@Test
 	public void testRoundRoundTripWhole () throws Exception {

--- a/binning-utilities/src/test/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIOTest.java
+++ b/binning-utilities/src/test/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIOTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2014 Oculus Info Inc.
+ * http://www.oculusinfo.com/
+ *
+ * Released under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.oculusinfo.binning.io.impl;
+
+import com.oculusinfo.binning.TileData;
+import com.oculusinfo.binning.TileIndex;
+import com.oculusinfo.binning.impl.DenseTileData;
+import com.oculusinfo.binning.io.serialization.TileSerializer;
+import com.oculusinfo.binning.io.serialization.impl.KryoSerializer;
+import com.oculusinfo.binning.io.serialization.impl.PrimitiveArrayAvroSerializer;
+import com.oculusinfo.binning.util.TypeDescriptor;
+import org.apache.avro.file.CodecFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class HBaseSlicedPyramidIOTest {
+	@Test
+	public void testRoundRoundTripWhole () throws Exception {
+		String table = "hbsioTest";
+		HBaseSlicedPyramidIO io = new HBaseSlicedPyramidIO("hadoop-s1", "2181", "hadoop-s1:60000");
+		TileSerializer<List<Integer>> serializer = new PrimitiveArrayAvroSerializer<>(Integer.class, CodecFactory.nullCodec());
+		try {
+			TileIndex index = new TileIndex(0, 0, 0, 1, 1);
+
+			TileData<List<Integer>> data = new DenseTileData<>(index);
+			data.setBin(0, 0, Arrays.asList(-0, -1, -2, -3, -4, -5, -6, -7));
+
+			io.initializeForWrite(table);
+			io.writeTiles(table, serializer, Arrays.asList(data));
+
+			// Check each slice
+			for (int i = 0; i < 8; ++i) {
+				List<TileData<List<Integer>>> slice = io.readTiles(table + "[" + i + "]", serializer, Arrays.asList(index));
+				Assert.assertEquals(1, slice.size());
+				TileData<List<Integer>> tile = slice.get(0);
+				List<Integer> bin = tile.getBin(0, 0);
+				Assert.assertEquals(1, bin.size());
+				Assert.assertEquals(-i, bin.get(0).intValue());
+			}
+
+			// Check the whole tile
+			List<TileData<List<Integer>>> slice = io.readTiles(table, serializer, Arrays.asList(index));
+			Assert.assertEquals(1, slice.size());
+			TileData<List<Integer>> tile = slice.get(0);
+			List<Integer> bin = tile.getBin(0, 0);
+			Assert.assertEquals(8, bin.size());
+			for (int i = 0; i < 8; ++i) {
+				Assert.assertEquals(-i, bin.get(i).intValue());
+			}
+		} finally {
+			io.dropTable(table);
+		}
+	}
+}


### PR DESCRIPTION
This currently will not work with Kryo serialization - kryo serializes what is literally there, so if we wrap the tile in a view, and try to write that view, it writes the tile itself behind the scenes.

Works just fine for avro though.

If we need Kryo, we'll need a specific tile view kryo serializer to register against the view classes when creating the kryo serializer.