### PR TITLE
Tile slice serialization

### DIFF
--- a/binning-utilities/src/main/java/com/oculusinfo/binning/impl/DenseTileData.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/impl/DenseTileData.java
@@ -198,4 +198,9 @@ public class DenseTileData<T> extends TileDataMetadataImpl<T> implements TileDat
 			return result;
 		}
 	}
+
+	@Override
+	public String toString () {
+		return "<dense-tile index=\""+getDefinition()+"\", default=\""+_default+"\"/>";
+	}
 }

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/impl/DenseTileData.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/impl/DenseTileData.java
@@ -99,6 +99,23 @@ public class DenseTileData<T> extends TileDataMetadataImpl<T> implements TileDat
 	 *            The data for this tile
 	 */
 	public DenseTileData(TileIndex definition, List<T> tileData) {
+		this(definition, null, tileData);
+	}
+
+	/**
+	 * Construct a tile for a particular tile index, with preset data. Note the passed-in preset data is used as is,
+	 * not copied.
+	 *
+	 * @param definition
+	 *            The index of the tile whose data is to be represented by this
+	 *            object.
+	 * @param defaultValue
+	 *            The default value to use for undefined bins; not used, since all bins are defined, but needed
+	 *            for some edge cases anyway (such as slicing, when a resultant slice ends up being sparse)
+	 * @param tileData
+	 *            The data for this tile
+	 */
+	public DenseTileData(TileIndex definition, T defaultValue, List<T> tileData) {
 
 		_definition = definition;
 		int requiredLength = _definition.getXBins() * _definition.getYBins();
@@ -110,6 +127,7 @@ public class DenseTileData<T> extends TileDataMetadataImpl<T> implements TileDat
 			                                   + tileData.size());
 		}
 		_data = tileData;
+		_default = defaultValue;
 	}
 
 	/** {@inheritDoc} */

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/impl/DenseTileMultiSliceView.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/impl/DenseTileMultiSliceView.java
@@ -121,8 +121,6 @@ public class DenseTileMultiSliceView<T> implements TileData<List<T>> {
 			}
 		}
 
-		System.out.println("Tile "+getDefinition()+": nullBins"+nullBins+", allBins: "+bins+", Dense: "+(nullBins*2 < bins));
-
 		return nullBins*2 < bins;
 	}
 

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/impl/DenseTileMultiSliceView.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/impl/DenseTileMultiSliceView.java
@@ -121,7 +121,7 @@ public class DenseTileMultiSliceView<T> implements TileData<List<T>> {
 			}
 		}
 
-		return nullBins*2 > bins;
+		return nullBins*2 < bins;
 	}
 
 	public TileData<List<T>> harden () {

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/impl/DenseTileMultiSliceView.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/impl/DenseTileMultiSliceView.java
@@ -121,6 +121,8 @@ public class DenseTileMultiSliceView<T> implements TileData<List<T>> {
 			}
 		}
 
+		System.out.println("Tile "+getDefinition()+": nullBins"+nullBins+", allBins: "+bins+", Dense: "+(nullBins*2 < bins));
+
 		return nullBins*2 < bins;
 	}
 

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/impl/FilterTileBucketView.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/impl/FilterTileBucketView.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2015 Uncharted Software. http://www.uncharted.software/
+ *
+ * Released under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.oculusinfo.binning.impl;
+
+
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import com.oculusinfo.binning.TileData;
+import com.oculusinfo.binning.TileIndex;
+
+
+
+/**
+ * This implementation of TileData takes a TileData whose bins are lists of buckets and presents
+ *  a view to a range of buckets.
+ *
+ */
+public class FilterTileBucketView<T> implements TileData<List<T>> {
+	private static final long serialVersionUID = 1234567890L;
+
+	private TileData<List<T>> _base = null;
+	private Integer	_startBucket = null;
+	private Integer	_endBucket = null;
+
+
+	public FilterTileBucketView (TileData<List<T>> base, Integer startBucket, Integer endBucket) {
+		_base = base;
+		_startBucket = startBucket;
+		_endBucket = endBucket;
+		if ( _startBucket != null && _endBucket != null ) {
+			if ( _startBucket < 0 || _startBucket > _endBucket ) {
+				throw new IllegalArgumentException( "Constructor for FilterTileBucketView: arguments are invalid.  start bucket: " + _startBucket + ", end bucket: " + _endBucket );
+			}
+		}
+	}
+
+
+	@Override
+	public TileIndex getDefinition () {
+		return _base.getDefinition();
+	}
+
+	@Override
+	public List<T> getDefaultValue () {
+		List<T> baseDefault = _base.getDefaultValue();
+		if (null == baseDefault) return null;
+		else {
+			List<T> ourDefault = new ArrayList<>();
+			int binSize = baseDefault.size();
+			int start = ( _startBucket != null ) ? _startBucket : 0;
+			int end = ( _endBucket != null && _endBucket < binSize ) ? _endBucket : binSize;
+
+			for(int i = 0; i < binSize; i++) {
+				if (i >= start && i <= end) ourDefault.add(baseDefault.get(i));
+				else ourDefault.add(null);
+			}
+			return ourDefault;
+		}
+	}
+
+	@Override
+	public void setBin(int x, int y, List<T> value)  {
+		if (x < 0 || x >= getDefinition().getXBins()) {
+			throw new IllegalArgumentException("Bin x index is outside of tile's valid bin range");
+		}
+		if (y < 0 || y >= getDefinition().getYBins()) {
+			throw new IllegalArgumentException("Bin y index is outside of tile's valid bin range");
+		}
+		_base.setBin( x, y, value );
+	}
+
+
+	@Override
+	public List<T> getBin (int x, int y) {
+		if (x < 0 || x >= getDefinition().getXBins()) {
+			throw new IllegalArgumentException("Bin x index is outside of tile's valid bin range");
+		}
+		if (y < 0 || y >= getDefinition().getYBins()) {
+			throw new IllegalArgumentException("Bin y index is outside of tile's valid bin range");
+		}
+
+		List<T> binContents = _base.getBin(x, y);
+		int binSize = binContents.size();
+		int start = ( _startBucket != null ) ? _startBucket : 0;
+		int end = ( _endBucket != null && _endBucket < binSize ) ? _endBucket : binSize;
+
+		for(int i = 0; i < binSize; i++) {
+			if ( i >= start && i <= end ) {
+				binContents.set(i, binContents.get(i));
+			} else {
+				binContents.set(i, null);
+			}
+		}
+		return binContents;
+	}
+
+
+	@Override
+	public Collection<String> getMetaDataProperties () {
+		return _base.getMetaDataProperties();
+	}
+
+
+	@Override
+	public String getMetaData (String property) {
+		return _base.getMetaData(property);
+	}
+
+
+	@Override
+	public void setMetaData (String property, Object value) {
+		_base.setMetaData(property, value);
+	}
+
+}

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/impl/SparseTileData.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/impl/SparseTileData.java
@@ -214,4 +214,9 @@ public class SparseTileData<T> extends TileDataMetadataImpl<T> implements TileDa
 			throw new UnsupportedOperationException("Illegal to remove elements from SparseTileData.getData()");
 		}
 	}
+
+	@Override
+	public String toString () {
+		return "<sparse-tile index=\""+getDefinition()+"\", default=\""+_defaultValue+"\"/>";
+	}
 }

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIO.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIO.java
@@ -109,7 +109,7 @@ public class HBaseSlicedPyramidIO extends HBasePyramidIO {
 			int slices = numSlices(tile);
 			// Divide the tile into slices, storing each of them individually in their own column
 			for (int s = 0; s < slices; ++s) {
-				TileData<List<T>> slice = new DenseTileMultiSliceView<T>(tile, s, s);
+				TileData<List<T>> slice = new DenseTileMultiSliceView<T>(tile, s, s).harden();
 				ByteArrayOutputStream baos = new ByteArrayOutputStream();
 				serializer.serialize(slice, baos);
 				existingPut = addToPut(existingPut, rowIdFromTileIndex(tile.getDefinition()),

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/GenericAvroSerializer.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/GenericAvroSerializer.java
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) 2014 Oculus Info Inc. 
+ * Copyright (c) 2014 Oculus Info Inc.
  * http://www.oculusinfo.com/
- * 
+ *
  * Released under the MIT License.
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
  * this software and associated documentation files (the "Software"), to deal in
  * the Software without restriction, including without limitation the rights to
@@ -119,7 +119,7 @@ abstract public class GenericAvroSerializer<T> implements TileSerializer<T> {
 		}
 		return _tileSchema.get().get(storage);
 	}
-	
+
 	protected Schema createTileSchema (StorageType storage) throws IOException {
 		switch (storage) {
 		case Dense:
@@ -130,7 +130,7 @@ abstract public class GenericAvroSerializer<T> implements TileSerializer<T> {
 			return null;
 		}
 	}
-	
+
 	@Override
 	public TypeDescriptor getBinTypeDescription () {
 		return _typeDescription;
@@ -153,9 +153,9 @@ abstract public class GenericAvroSerializer<T> implements TileSerializer<T> {
 
 		DatumReader<GenericRecord> reader = new GenericDatumReader<GenericRecord>();
 		DataFileStream<GenericRecord> dataFileReader = new DataFileStream<GenericRecord>(stream, reader);
-    	
+
 		try {
-        	
+
 			GenericRecord r = dataFileReader.next();
 
 			int level = (Integer) r.get("level");
@@ -187,8 +187,9 @@ abstract public class GenericAvroSerializer<T> implements TileSerializer<T> {
 					++i;
 					if (i >= xBins * yBins) break;
 				}
+				T defaultValue = getValue((GenericRecord) r.get("default"));
 
-				newTile = new DenseTileData<T>(newTileIndex, data);
+				newTile = new DenseTileData<T>(newTileIndex, defaultValue, data);
 				break;
 			}
 			case Sparse: {
@@ -267,7 +268,7 @@ abstract public class GenericAvroSerializer<T> implements TileSerializer<T> {
 		tileRecord.put("meta", getTileMetaData(tile));
 
 		GenericRecord defaultValueRecord = new GenericData.Record(recordSchema);
-		setValue(defaultValueRecord, tile.getDefaultBinValue());
+		setValue(defaultValueRecord, tile.getDefaultValue());
 		tileRecord.put("default", defaultValueRecord);
 
 		writeRecord(tileRecord, tileSchema, stream);
@@ -294,8 +295,11 @@ abstract public class GenericAvroSerializer<T> implements TileSerializer<T> {
 		tileRecord.put("xBinCount", idx.getXBins());
 		tileRecord.put("yBinCount", idx.getYBins());
 		tileRecord.put("values", bins);
-		tileRecord.put("default", null);
 		tileRecord.put("meta", getTileMetaData(tile));
+
+		GenericRecord defaultValueRecord = new GenericData.Record(recordSchema);
+		setValue(defaultValueRecord, tile.getDefaultValue());
+		tileRecord.put("default", defaultValueRecord);
 
 		writeRecord(tileRecord, tileSchema, stream);
 	}

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/impl/PrimitiveAvroSerializer.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/impl/PrimitiveAvroSerializer.java
@@ -130,9 +130,9 @@ public class PrimitiveAvroSerializer<T> extends GenericAvroSerializer<T> {
 		return _schema;
 	}
 
-	// This doesn't need to be checked because 
+	// This doesn't need to be checked because
 	//  (a) One can't create a serializer for which it theoreticallly won't work.
-	//  (b) It is possible to use the wrong serializer for a given tile, in which 
+	//  (b) It is possible to use the wrong serializer for a given tile, in which
 	//      case it will fail - but it should fail in that case.
 	@SuppressWarnings("unchecked")
 	@Override
@@ -141,6 +141,9 @@ public class PrimitiveAvroSerializer<T> extends GenericAvroSerializer<T> {
 			// A bit of a hack to handle string tiles as strings rather than Utf8s
 			return (T) bin.get("value").toString();
 		} else {
+			if (null == bin || null == bin.get("value")) {
+				return null;
+			}
 			return (T) bin.get("value");
 		}
 	}

--- a/binning-utilities/src/main/resources/denseTile.avsc
+++ b/binning-utilities/src/main/resources/denseTile.avsc
@@ -2,7 +2,7 @@
   "name" : "denseTile",
   "namespace" : "ar.avro",
   "type" : "record",
-  "fields" : 
+  "fields" :
     [
       {"name": "level", "type": "int",
        "doc": "The Z-level at which this tile lies.  Z=0 is the least-precise (zoomed-farthest-out) tile"},
@@ -19,10 +19,10 @@
        "type": {"type": "array", "items": "ar.avro.recordType" },
        "doc": "The actual data for this tile"},
 
-      {"name": "default", "type": ["ar.avro.recordType","null"], "default":"null",
+      {"name": "default", "type": ["null", "ar.avro.recordType"], "default":null,
         "doc": "Default value inside the system.  Analogous to an image's background color or null"},
 
-      {"name": "meta", "type":[{"type":"map", "values":"string"}, "null"], "default":"null",
+      {"name": "meta", "type":["null", {"type":"map", "values":"string"}], "default":null,
         "doc": "Pass-through metadata location.  For things like provenance, time stamps, etc."}
     ]
 }

--- a/binning-utilities/src/main/resources/sparseTile.avsc
+++ b/binning-utilities/src/main/resources/sparseTile.avsc
@@ -32,10 +32,10 @@
         "doc": "The actual data for this tile"
       },
 
-      {"name": "default", "type": ["ar.avro.recordType","null"], "default":"null",
+      {"name": "default", "type": ["null", "ar.avro.recordType"], "default":null,
         "doc": "Default value inside the system.  Analogous to an image's background color or null"},
 
-      {"name": "meta", "type":[{"type":"map", "values":"string"}, "null"], "default":"null",
+      {"name": "meta", "type":["null", {"type":"map", "values":"string"}], "default":null,
         "doc": "Pass-through metadata location.  For things like provenance, time stamps, etc."}
     ]
 }

--- a/binning-utilities/src/test/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIOTest.java
+++ b/binning-utilities/src/test/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIOTest.java
@@ -31,6 +31,7 @@ import com.oculusinfo.binning.impl.SparseTileData;
 import com.oculusinfo.binning.io.serialization.TileSerializer;
 import com.oculusinfo.binning.io.serialization.impl.KryoSerializer;
 import com.oculusinfo.binning.io.serialization.impl.PrimitiveArrayAvroSerializer;
+import com.oculusinfo.binning.io.serialization.impl.PrimitiveAvroSerializer;
 import com.oculusinfo.binning.util.TypeDescriptor;
 import com.oculusinfo.factory.util.Pair;
 import org.apache.avro.file.CodecFactory;
@@ -84,24 +85,24 @@ public class HBaseSlicedPyramidIOTest {
 	@Test
 	public void testRelativeReadSpeed () throws Exception {
 		int iterations = 100;
+		int slices = 52;
 		HBaseSlicedPyramidIO io = new HBaseSlicedPyramidIO("hadoop-s1", "2181", "hadoop-s1:60000");
-		TileSerializer<List<Integer>> serializer = new PrimitiveArrayAvroSerializer<>(Integer.class, CodecFactory.nullCodec());
-		String table = "heatmapTimeDebug-sliced";
-		TileIndex index = new TileIndex(0, 0, 0);
-		List<TileIndex> indices = Arrays.asList(index);
+		TileSerializer<List<Integer>> serializer = new PrimitiveArrayAvroSerializer<>(Integer.class, CodecFactory.bzip2Codec());
+		String table = "nycTaxiDropoffsHeatmap_sw2015_sliced";
+		List<TileIndex> indices = Arrays.asList(new TileIndex(9,151,319));
 
 		System.out.println("Reading full tile");
 		TileData<List<Integer>> full = null;
 		long startFull = System.currentTimeMillis();
 		for (int i=0; i<iterations; ++i) {
-			for (int s=0; s<14; ++s) {
+			for (int s=0; s<slices; ++s) {
 				full = io.readTiles(table, serializer, indices).get(0);
 			}
 		}
 		long endFull = System.currentTimeMillis();
 
 		System.out.println("Checking slice contents");
-		for (int s=0; s<14; ++s) {
+		for (int s=0; s<slices; ++s) {
 			TileData<List<Integer>> slice = io.readTiles(table + "["+s+"]", serializer, indices).get(0);
 			for (int x=0; x<full.getDefinition().getXBins(); ++x) {
 				for (int y=0; y<full.getDefinition().getYBins(); ++y) {
@@ -110,7 +111,7 @@ public class HBaseSlicedPyramidIOTest {
 					if (null == fullBin || 0 == fullBin.size()) {
 						Assert.assertTrue(null == sliceBin || 0 == sliceBin.size());
 					} else {
-						Assert.assertEquals(14, fullBin.size());
+						Assert.assertEquals(slices, fullBin.size());
 						Assert.assertEquals(1, sliceBin.size());
 						Assert.assertEquals(fullBin.get(s), sliceBin.get(0));
 					}
@@ -121,13 +122,26 @@ public class HBaseSlicedPyramidIOTest {
 		System.out.println("Reading sliced tiles");
 		long startSlice = System.currentTimeMillis();
 		for (int i=0; i<iterations; ++i) {
-			for (int s=0; s<14; ++s) {
+			for (int s=0; s<slices; ++s) {
 				io.readTiles(table + "["+s+"]", serializer, indices);
 			}
 		}
 		long endSlice = System.currentTimeMillis();
 
+		System.out.println("Reading unsliced tiles");
+		indices = Arrays.asList(new TileIndex(0, 0, 0));
+		TileSerializer<Double> dSerializer = new PrimitiveAvroSerializer<>(Double.class, CodecFactory.bzip2Codec());
+		String singleSliceTable = "twitter-ebola-p1-heatmap";
+		long startSingle = System.currentTimeMillis();
+		for (int i=0; i<iterations; ++i) {
+			for (int s=0; s<slices; ++s) {
+				io.readTiles(singleSliceTable, dSerializer, indices);
+			}
+		}
+		long endSingle = System.currentTimeMillis();
+
 		System.out.println("Time for full tile: " + ((endFull - startFull) / 1000.0));
 		System.out.println("Time for slices: "+((endSlice-startSlice)/1000.0));
+		System.out.println("Time for unsliced table: "+((endSingle-startSingle)/1000.0));
 	}
 }

--- a/binning-utilities/src/test/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIOTest.java
+++ b/binning-utilities/src/test/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIOTest.java
@@ -43,6 +43,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
+@Ignore
 public class HBaseSlicedPyramidIOTest {
 	@Test
 	public void testRoundRoundTripWhole () throws Exception {
@@ -84,7 +85,7 @@ public class HBaseSlicedPyramidIOTest {
 
 	@Test
 	public void testRelativeReadSpeed () throws Exception {
-		int iterations = 100;
+		int iterations = 2;
 		int slices = 52;
 		HBaseSlicedPyramidIO io = new HBaseSlicedPyramidIO("hadoop-s1", "2181", "hadoop-s1:60000");
 		TileSerializer<List<Integer>> serializer = new PrimitiveArrayAvroSerializer<>(Integer.class, CodecFactory.bzip2Codec());

--- a/binning-utilities/src/test/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIOTest.java
+++ b/binning-utilities/src/test/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIOTest.java
@@ -23,19 +23,23 @@
  */
 package com.oculusinfo.binning.io.impl;
 
+import com.oculusinfo.binning.BinIndex;
 import com.oculusinfo.binning.TileData;
 import com.oculusinfo.binning.TileIndex;
 import com.oculusinfo.binning.impl.DenseTileData;
+import com.oculusinfo.binning.impl.SparseTileData;
 import com.oculusinfo.binning.io.serialization.TileSerializer;
 import com.oculusinfo.binning.io.serialization.impl.KryoSerializer;
 import com.oculusinfo.binning.io.serialization.impl.PrimitiveArrayAvroSerializer;
 import com.oculusinfo.binning.util.TypeDescriptor;
+import com.oculusinfo.factory.util.Pair;
 import org.apache.avro.file.CodecFactory;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 
 public class HBaseSlicedPyramidIOTest {
@@ -79,23 +83,47 @@ public class HBaseSlicedPyramidIOTest {
 
 	@Test
 	public void testRelativeReadSpeed () throws Exception {
+		int iterations = 100;
 		HBaseSlicedPyramidIO io = new HBaseSlicedPyramidIO("hadoop-s1", "2181", "hadoop-s1:60000");
 		TileSerializer<List<Integer>> serializer = new PrimitiveArrayAvroSerializer<>(Integer.class, CodecFactory.nullCodec());
 		String table = "heatmapTimeDebug-sliced";
 		TileIndex index = new TileIndex(0, 0, 0);
 		List<TileIndex> indices = Arrays.asList(index);
 
+		System.out.println("Reading full tile");
+		TileData<List<Integer>> full = null;
 		long startFull = System.currentTimeMillis();
-		for (int i=0; i<256; ++i) {
-			io.readTiles(table, serializer, indices);
+		for (int i=0; i<iterations; ++i) {
+			for (int s=0; s<14; ++s) {
+				full = io.readTiles(table, serializer, indices).get(0);
+			}
 		}
 		long endFull = System.currentTimeMillis();
 
+		System.out.println("Checking slice contents");
+		for (int s=0; s<14; ++s) {
+			TileData<List<Integer>> slice = io.readTiles(table + "["+s+"]", serializer, indices).get(0);
+			for (int x=0; x<full.getDefinition().getXBins(); ++x) {
+				for (int y=0; y<full.getDefinition().getYBins(); ++y) {
+					List<Integer> fullBin = full.getBin(x, y);
+					List<Integer> sliceBin = slice.getBin(x, y);
+					if (null == fullBin || 0 == fullBin.size()) {
+						Assert.assertTrue(null == sliceBin || 0 == sliceBin.size());
+					} else {
+						Assert.assertEquals(14, fullBin.size());
+						Assert.assertEquals(1, sliceBin.size());
+						Assert.assertEquals(fullBin.get(s), sliceBin.get(0));
+					}
+				}
+			}
+		}
+
+		System.out.println("Reading sliced tiles");
 		long startSlice = System.currentTimeMillis();
-		for (int i=0; i<256; ++i) {
-			List<TileData<List<Integer>>> slices = io.readTiles(table + "["+i+"]", serializer, indices);
-			TileData<List<Integer>> slice = slices.get(0);
-			int bins = slice.getDefinition().getXBins();
+		for (int i=0; i<iterations; ++i) {
+			for (int s=0; s<14; ++s) {
+				io.readTiles(table + "["+s+"]", serializer, indices);
+			}
 		}
 		long endSlice = System.currentTimeMillis();
 


### PR DESCRIPTION
Allows serialization into avro by slice.

Current slices are single-time-bucket only.  They could be pyramided, or consolidated in any pattern, with a little bit of work.

This also fixes the warnings we get out of Avro when serializing/deserializing about null meta and default values.