### PR TITLE
Speed up reading of bucketted tiles

### DIFF
--- a/binning-utilities/src/main/java/com/oculusinfo/binning/impl/DenseTileMultiSliceView.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/impl/DenseTileMultiSliceView.java
@@ -33,7 +33,7 @@ import java.util.List;
 
 /**
  * This implementation of TileData takes a TileData whose bins are lists of buckets, and presents
- * a view to a single slice of it - the same bucket in each bin.
+ * a view to a subset of those buckets - the same buckets in each bin.
  *
  * @author nkronenfeld
  */
@@ -57,7 +57,16 @@ public class DenseTileMultiSliceView<T> implements TileData<List<T>> {
 	}
 
 	@Override
-	public List<T> getDefaultValue() { return _base.getDefaultValue(); }
+	public List<T> getDefaultValue() {
+		List<T> base = _base.getDefaultValue();
+		if (null == base) return null;
+		List<T> ourDefault = new ArrayList<>();
+		for (int slice: _slices) {
+			if (base.size() > slice) ourDefault.add(base.get(slice));
+			else ourDefault.add(null);
+		}
+		return ourDefault;
+	}
 
 	@Override
 	public void setBin(int x, int y, List<T> value) {

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/impl/MultiSliceTileView.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/impl/MultiSliceTileView.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2015 Uncharted Software Inc. http://www.uncharted.software/
+ *
+ * Released under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.oculusinfo.binning.impl;
+
+import com.oculusinfo.binning.TileData;
+import com.oculusinfo.binning.TileIndex;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This implementation of TileData takes a several TileDatas whose bins are lists of buckets, and presents
+ * a view to single tile, whose bins are composed of the bins of each component tile.
+ *
+ * No effort is made to check for consistent lengths of buckets between bins; therefore setting bin values is
+ * disallowed (since we don't know the length to apply to each component).
+ *
+ * @author nkronenfeld
+ */
+public class MultiSliceTileView<T> implements TileData<List<T>> {
+	List<TileData<List<T>>> _components;
+	public MultiSliceTileView (List<TileData<List<T>>> components) {
+		TileIndex i0 = null;
+		for (TileData<List<T>> component: components) {
+			if (null == i0) i0 = component.getDefinition();
+			else if (!i0.equals(component.getDefinition()))
+				throw new IllegalArgumentException("Attempt to create a multislice tile view with incompatible components");
+		}
+		_components = Collections.unmodifiableList(new ArrayList<>(components));
+	}
+
+	@Override
+	public TileIndex getDefinition() {
+		return _components.get(0).getDefinition();
+	}
+
+	@Override
+	public List<T> getDefaultValue() {
+		List<T> ourDefault = new ArrayList<>();
+		for (TileData<List<T>> component: _components) {
+			List<T> componentDefault = component.getDefaultValue();
+			if (null == componentDefault)
+				// If one component has a null default, we can't aggregate any of the defaults properly.
+				return null;
+			ourDefault.addAll(componentDefault);
+		}
+		return ourDefault;
+	}
+
+	@Override
+	public void setBin(int x, int y, List<T> value) {
+		throw new UnsupportedOperationException("Setting values of multi-slice tile views isn't allowed - see class javadocs");
+	}
+
+	@Override
+	public List<T> getBin(int x, int y) {
+		List<T> binValue = new ArrayList<>();
+		for (TileData<List<T>> component: _components) {
+			List<T> componentBin = component.getBin(x, y);
+			if (null == componentBin)
+				// Because we don't know the standard bin length of each component, if any are null, we have to give
+				// up.
+				return null;
+			else
+				binValue.addAll(componentBin);
+		}
+		return binValue;
+	}
+
+	@Override
+	public Collection<String> getMetaDataProperties() {
+		return _components.get(0).getMetaDataProperties();
+	}
+
+	@Override
+	public String getMetaData(String property) {
+		return _components.get(0).getMetaData(property);
+	}
+
+	@Override
+	public void setMetaData(String property, Object value) {
+		// We could allow this, but for consistence with setBin, we don't.
+		throw new UnsupportedOperationException("Setting values of multi-slice tile views isn't allowed - see class javadocs");
+	}
+}

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/HBasePyramidIO.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/HBasePyramidIO.java
@@ -295,13 +295,13 @@ public class HBasePyramidIO implements PyramidIO {
 	protected <T> List<TileData<T>> readTiles (String tableName,
 											   TileSerializer<T> serializer,
 											   Iterable<TileIndex> tiles,
-											   HBaseColumn column) throws IOException {
+											   HBaseColumn... columns) throws IOException {
 		List<String> rowIds = new ArrayList<String>();
 		for (TileIndex tile: tiles) {
 			rowIds.add(rowIdFromTileIndex(tile));
 		}
 
-		List<Map<HBaseColumn, byte[]>> rawResults = readRows(tableName, rowIds, column);
+		List<Map<HBaseColumn, byte[]>> rawResults = readRows(tableName, rowIds, columns);
 
 		List<TileData<T>> results = new LinkedList<TileData<T>>();
 
@@ -312,10 +312,12 @@ public class HBasePyramidIO implements PyramidIO {
 			Map<HBaseColumn, byte[]> rawResult = iData.next();
 			TileIndex index = indexIterator.next();
 			if (null != rawResult) {
-				byte[] rawData = rawResult.get(column);
-				ByteArrayInputStream bais = new ByteArrayInputStream(rawData);
-				TileData<T> data = serializer.deserialize(index, bais);
-				results.add(data);
+				for (HBaseColumn column: columns) {
+					byte[] rawData = rawResult.get(column);
+					ByteArrayInputStream bais = new ByteArrayInputStream(rawData);
+					TileData<T> data = serializer.deserialize(index, bais);
+					results.add(data);
+				}
 			}
 		}
 

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIO.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIO.java
@@ -28,11 +28,13 @@ import com.oculusinfo.binning.TileIndex;
 import com.oculusinfo.binning.impl.DenseTileMultiSliceView;
 import com.oculusinfo.binning.io.serialization.TileSerializer;
 import com.oculusinfo.binning.util.TypeDescriptor;
+import com.oculusinfo.factory.util.Pair;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Row;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -87,6 +89,62 @@ public class HBaseSlicedPyramidIO extends HBasePyramidIO {
 		}
 	}
 
+	// Convert a number to its base 2 representation, as an array of 0's and 1's
+	private static int[] numberToBits (int number) {
+		// Count how many bits there are
+		int numBits = 0;
+		for (int n = number; n > 0; n = n >> 1) ++numBits;
+		int[] bits = new int[numBits];
+		for (int n=0; n<numBits; ++n) {
+			bits[n] = 1 & (number >> n);
+		}
+		return bits;
+	}
+
+	/**
+	 * Take a range of buckets, and convert it into the best set of requests for retrieving that set of buckets from a
+	 * fully pyramidded bucket tile set.
+	 *
+	 * @param start The first bucket needed
+	 * @param end The last bucket needed
+	 * @return A series of pairs, each of which indicates a single stored bucket range to be retrieved, with its
+	 *         start end end bucket number.
+	 */
+	public static List<Pair<Integer, Integer>> decomposeRange (int start, int end) {
+		if (start > end) return decomposeRange(end, start);
+
+		// Get the most significant bit at which the endpoints differ.
+		int differences = start ^ (end+1); // xor
+		int msb = 1;
+		while ((msb << 1) <= differences) msb = msb << 1;
+		int midPoint = start - (start % msb) + msb;
+
+		int[] startRanges = numberToBits(midPoint - start);;
+		int[] endRanges = numberToBits(end + 1 - midPoint);
+
+		// Construct our ranges.
+		List<Pair<Integer, Integer>> ranges = new ArrayList<>();
+		int curRangeMin = start;
+
+		// Ranges before our midpoint go from smallest to largest
+		for (int i=0; i<startRanges.length; ++i) {
+			if (1 == startRanges[i]) {
+				int curRangeSize = 1 << i;
+				ranges.add(new Pair<Integer, Integer>(curRangeMin, curRangeMin+curRangeSize-1));
+				curRangeMin += curRangeSize;
+			}
+		}
+		// Ranges after our midpoint go from largest to smallest
+		for (int i=endRanges.length-1; i>=0; --i) {
+			if (1 == endRanges[i]) {
+				int curRangeSize = 1 << i;
+				ranges.add(new Pair<Integer, Integer>(curRangeMin, curRangeMin+curRangeSize-1));
+				curRangeMin += curRangeSize;
+			}
+		}
+
+		return ranges;
+	}
 
 
 	public static class SlicedHBaseTilePutter extends StandardHBaseTilePutter {

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIO.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIO.java
@@ -128,10 +128,10 @@ public class HBaseSlicedPyramidIO extends HBasePyramidIO {
 				for (int i=0; i<numReal; ++i) {
 					// We know this cast is correct because of our guard condition up top, that
 					// List is the main type of T.
-					realResults.add(compose((List) rawResults, i, numReal, columns.length));
+					realResults.add(compose((List) rawResults, i, columns.length, numReal));
 				}
+				return realResults;
 			}
-			return rawResults;
 		} else {
 			return super.readTiles(tableName, serializer, tiles);
 		}

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/impl/KryoSerializer.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/impl/KryoSerializer.java
@@ -66,7 +66,7 @@ public class KryoSerializer<T> implements TileSerializer<T> {
 	 *            violating it will cause a host of problems.
 	 */
 	public KryoSerializer (TypeDescriptor typeDesc, Class<?>... classesToRegister) {
-		this(typeDesc, Codec.BZIP, classesToRegister);
+		this(typeDesc, Codec.GZIP, classesToRegister);
 	}
 	public KryoSerializer (TypeDescriptor typeDesc, Codec codec, Class<?>... classesToRegister) {
 		_typeDesc = typeDesc;

--- a/binning-utilities/src/test/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIOTest.java
+++ b/binning-utilities/src/test/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIOTest.java
@@ -85,11 +85,11 @@ public class HBaseSlicedPyramidIOTest {
 
 	@Test
 	public void testRelativeReadSpeed () throws Exception {
-		int iterations = 2;
-		int slices = 52;
+		int iterations = 1;
+		int slices = 53;
 		HBaseSlicedPyramidIO io = new HBaseSlicedPyramidIO("hadoop-s1", "2181", "hadoop-s1:60000");
-		TileSerializer<List<Integer>> serializer = new PrimitiveArrayAvroSerializer<>(Integer.class, CodecFactory.bzip2Codec());
-		String table = "nycTaxiDropoffsHeatmap_sw2015_sliced";
+		TileSerializer<List<Integer>> ks = new KryoSerializer<List<Integer>>(new TypeDescriptor(List.class, new TypeDescriptor(Integer.class)));
+		String table = "nycTaxiHeatmap_sw2015_weekly";
 		List<TileIndex> indices = Arrays.asList(new TileIndex(9,151,319));
 
 		System.out.println("Reading full tile");
@@ -97,14 +97,14 @@ public class HBaseSlicedPyramidIOTest {
 		long startFull = System.currentTimeMillis();
 		for (int i=0; i<iterations; ++i) {
 			for (int s=0; s<slices; ++s) {
-				full = io.readTiles(table, serializer, indices).get(0);
+				full = io.readTiles(table, ks, indices).get(0);
 			}
 		}
 		long endFull = System.currentTimeMillis();
 
 		System.out.println("Checking slice contents");
 		for (int s=0; s<slices; ++s) {
-			TileData<List<Integer>> slice = io.readTiles(table + "["+s+"]", serializer, indices).get(0);
+			TileData<List<Integer>> slice = io.readTiles(table + "["+s+"]", ks, indices).get(0);
 			for (int x=0; x<full.getDefinition().getXBins(); ++x) {
 				for (int y=0; y<full.getDefinition().getYBins(); ++y) {
 					List<Integer> fullBin = full.getBin(x, y);
@@ -124,7 +124,7 @@ public class HBaseSlicedPyramidIOTest {
 		long startSlice = System.currentTimeMillis();
 		for (int i=0; i<iterations; ++i) {
 			for (int s=0; s<slices; ++s) {
-				io.readTiles(table + "["+s+"]", serializer, indices);
+				io.readTiles(table + "["+s+"]", ks, indices);
 			}
 		}
 		long endSlice = System.currentTimeMillis();

--- a/binning-utilities/src/test/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIOTest.java
+++ b/binning-utilities/src/test/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIOTest.java
@@ -24,10 +24,12 @@
 package com.oculusinfo.binning.io.impl;
 
 import com.oculusinfo.binning.BinIndex;
+import com.oculusinfo.binning.TileAndBinIndices;
 import com.oculusinfo.binning.TileData;
 import com.oculusinfo.binning.TileIndex;
 import com.oculusinfo.binning.impl.DenseTileData;
 import com.oculusinfo.binning.impl.SparseTileData;
+import com.oculusinfo.binning.io.PyramidIO;
 import com.oculusinfo.binning.io.serialization.TileSerializer;
 import com.oculusinfo.binning.io.serialization.impl.KryoSerializer;
 import com.oculusinfo.binning.io.serialization.impl.PrimitiveArrayAvroSerializer;
@@ -35,13 +37,28 @@ import com.oculusinfo.binning.io.serialization.impl.PrimitiveAvroSerializer;
 import com.oculusinfo.binning.util.TypeDescriptor;
 import com.oculusinfo.factory.util.Pair;
 import org.apache.avro.file.CodecFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.filter.FirstKeyOnlyFilter;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 @Ignore
 public class HBaseSlicedPyramidIOTest {
@@ -258,5 +275,197 @@ public class HBaseSlicedPyramidIOTest {
 		}
 		Assert.assertTrue(pDiffs, 0 == pDiffs.length());
 		Assert.assertTrue(iDiffs, 0 == iDiffs.length());
+	}
+
+
+	@Test
+	public void testDenseSlicedTiles () throws Exception {
+		TileIndex index = new TileIndex(0, 0, 0, 4, 4);
+		TileData<List<Integer>> tile = new DenseTileData<>(index);
+		for (int x=0; x<4; ++x) {
+			for (int y=0; y<4; ++y) {
+				List<Integer> bin = new ArrayList<>();
+				for (int z=0; z<4; ++z) {
+					bin.add(x+y+z);
+				}
+				tile.setBin(x, y, bin);
+			}
+		}
+
+		String table = "dense-bucket-test";
+		HBaseSlicedPyramidIO io = new HBaseSlicedPyramidIO("hadoop-s1", "2181", "hadoop-s1:60000");
+		TileSerializer<List<Integer>> serializer = new KryoSerializer<>(new TypeDescriptor(List.class, new TypeDescriptor(Integer.class)));
+
+		io.initializeForWrite(table);
+		io.writeTiles(table, serializer, Arrays.asList(tile));
+
+		List<TileIndex> indices = Arrays.asList(index);
+		TileData<List<Integer>> full = io.readTiles(table, serializer, indices).get(0);
+		TileData<List<Integer>> s0 = io.readTiles(table+"[0]", serializer, indices).get(0);
+		TileData<List<Integer>> s1 = io.readTiles(table+"[1]", serializer, indices).get(0);
+		TileData<List<Integer>> s2 = io.readTiles(table+"[2]", serializer, indices).get(0);
+		TileData<List<Integer>> s3 = io.readTiles(table+"[3]", serializer, indices).get(0);
+		List<TileData<List<Integer>>> slices = Arrays.asList(s0, s1, s2, s3);
+		TileData<List<Integer>> s01 = io.readTiles(table+"[0-1]", serializer, indices).get(0);
+		TileData<List<Integer>> s23 = io.readTiles(table+"[2-3]", serializer, indices).get(0);
+		List<TileData<List<Integer>>> slicePairs = Arrays.asList(s01, s23);
+
+		for (int x=0; x<4; ++x) {
+			for (int y=0; y<4; ++y) {
+				for (int z=0; z<4; ++z) {
+					Assert.assertEquals(tile.getBin(x, y).get(z), full.getBin(x, y).get(z));
+					Assert.assertEquals(tile.getBin(x, y).get(z), slices.get(z).getBin(x, y).get(0));
+					Assert.assertEquals(tile.getBin(x, y).get(z), slicePairs.get(z/2).getBin(x, y).get(z%2));
+				}
+			}
+		}
+	}
+
+	// List out all indices in the given weird tile set, for use in the next test
+	@Ignore
+	public void listIndices () throws Exception {
+		String tableName = "nycHeatmap_sw2015_sliced_DELETEME";
+		String zookeeperQuorum = "hadoop-s1";
+		String zookeeperPort = "2181";
+		String hbaseMaster = "hadoop-s1:60000";
+
+		Configuration config = HBaseConfiguration.create();
+		config.set("hbase.zookeeper.quorum", zookeeperQuorum);
+		config.set("hbase.zookeeper.property.clientPort", zookeeperPort);
+		config.set("hbase.master", hbaseMaster);
+		config.set("hbase.client.keyvalue.maxsize", "0");
+		Connection connection = ConnectionFactory.createConnection(config);
+		Admin admin = connection.getAdmin();
+		Table table = connection.getTable(TableName.valueOf(tableName));
+
+		System.out.println("scanning full table:");
+		Scan scan = new Scan();
+		scan.setFilter(new FirstKeyOnlyFilter());
+		ResultScanner scanner = table.getScanner(scan);
+		for (Result rr : scanner) {
+			byte[] key = rr.getRow();
+			String keyName = new String(key);
+			System.out.println(keyName);
+		}
+	}
+
+	private <T> Map<TileIndex, TileData<T>> getTileMap (PyramidIO io, TileSerializer<T> serializer,
+														String table, Integer slice, List<TileIndex> indices) throws Exception {
+		if (null != slice) {
+			table = table + "[" + slice + "]";
+		}
+		List<TileData<T>> tiles = io.readTiles(table, serializer, indices);
+		Map<TileIndex, TileData<T>> result = new HashMap<>();
+		for (TileData<T> tile: tiles) {
+			result.put(tile.getDefinition(), tile);
+		}
+		return result;
+	}
+	List<Integer> addLists (List<Integer> a, List<Integer> b) {
+		if (null == a || 0 == a.size()) return b;
+		if (null == b || 0 == b.size()) return a;
+		List<Integer> c = new ArrayList<>();
+		int N = Math.max(a.size(), b.size());
+		for (int n=0; n<N; ++n) {
+			int v = 0;
+			if (n < a.size()) v += a.get(n);
+			if (n < b.size()) v += b.get(n);
+			c.add(v);
+		}
+		return c;
+	}
+
+	// Make sure the various levels match in a weird tile set - i.e., make sure there are no lower-level holes that
+	// don't also exist at upper levels.
+	@Test
+	public void testWeirdTable () throws Exception {
+		String table = "nycHeatmap_sw2015_sliced_DELETEME";
+		HBaseSlicedPyramidIO io = new HBaseSlicedPyramidIO("hadoop-s1", "2181", "hadoop-s1:60000");
+		TileSerializer<List<Integer>> serializer = new KryoSerializer<>(new TypeDescriptor(List.class, new TypeDescriptor(Integer.class)));
+
+		for (int slice = 0; slice < 53; ++slice) {
+			Map<TileIndex, TileData<List<Integer>>> level8 =
+				getTileMap(io, serializer, table, slice,
+					Arrays.asList(new TileIndex(8, 75, 159)));
+			Map<TileIndex, TileData<List<Integer>>> level9 =
+				getTileMap(io, serializer, table, slice,
+					Arrays.asList(new TileIndex(9, 150, 319), new TileIndex(9, 151, 319)));
+			Map<TileIndex, TileData<List<Integer>>> level10 =
+				getTileMap(io, serializer, table, slice,
+					Arrays.asList(new TileIndex(10, 300, 638), new TileIndex(10, 301, 638),
+						new TileIndex(10, 301, 639), new TileIndex(10, 302, 638),
+						new TileIndex(10, 302, 639)));
+			Map<TileIndex, TileData<List<Integer>>> level11 =
+				getTileMap(io, serializer, table, slice,
+					Arrays.asList(new TileIndex(11, 601, 1276), new TileIndex(11, 601, 1277),
+						new TileIndex(11, 602, 1276), new TileIndex(11, 602, 1277),
+						new TileIndex(11, 602, 1278), new TileIndex(11, 603, 1276),
+						new TileIndex(11, 603, 1277), new TileIndex(11, 603, 1278),
+						new TileIndex(11, 603, 1279), new TileIndex(11, 604, 1276),
+						new TileIndex(11, 604, 1277), new TileIndex(11, 604, 1278),
+						new TileIndex(11, 604, 1279)));
+			Map<TileIndex, TileData<List<Integer>>> level12 =
+				getTileMap(io, serializer, table, slice,
+					Arrays.asList(new TileIndex(12, 1202, 2552), new TileIndex(12, 1202, 2553),
+						new TileIndex(12, 1203, 2552), new TileIndex(12, 1203, 2553),
+						new TileIndex(12, 1203, 2554), new TileIndex(12, 1203, 2555),
+						new TileIndex(12, 1204, 2552), new TileIndex(12, 1204, 2553),
+						new TileIndex(12, 1204, 2554), new TileIndex(12, 1204, 2555),
+						new TileIndex(12, 1205, 2554), new TileIndex(12, 1205, 2555),
+						new TileIndex(12, 1205, 2556), new TileIndex(12, 1206, 2553),
+						new TileIndex(12, 1206, 2554), new TileIndex(12, 1206, 2555),
+						new TileIndex(12, 1206, 2556), new TileIndex(12, 1206, 2557),
+						new TileIndex(12, 1206, 2558), new TileIndex(12, 1207, 2553),
+						new TileIndex(12, 1207, 2554), new TileIndex(12, 1207, 2555),
+						new TileIndex(12, 1207, 2556), new TileIndex(12, 1207, 2557),
+						new TileIndex(12, 1207, 2558), new TileIndex(12, 1208, 2553),
+						new TileIndex(12, 1208, 2554), new TileIndex(12, 1208, 2555),
+						new TileIndex(12, 1208, 2556), new TileIndex(12, 1208, 2557),
+						new TileIndex(12, 1208, 2558), new TileIndex(12, 1209, 2554),
+						new TileIndex(12, 1209, 2555), new TileIndex(12, 1209, 2556)));
+
+			Map<Integer, Map<TileIndex, TileData<List<Integer>>>> allTiles = new HashMap<>();
+			allTiles.put(8, level8);
+			allTiles.put(9, level9);
+			allTiles.put(10, level10);
+			allTiles.put(11, level11);
+			allTiles.put(12, level12);
+
+			for (int t = 8; t < 12; ++t) {
+				for (TileData<List<Integer>> topTile : allTiles.get(t).values()) {
+					TileIndex topIdx = topTile.getDefinition();
+					for (int b = t + 1; b < 13; ++b) {
+						int lf = 1 << (b - t);
+						for (int x = 0; x < 256; ++x) {
+							for (int y = 0; y < 256; ++y) {
+								List<Integer> expected = topTile.getBin(x, y);
+								List<Integer> actual = null;
+								BinIndex baseTopUBin = TileIndex.tileBinIndexToUniversalBinIndex(topIdx, new BinIndex(x, y));
+								BinIndex baseUBin = new BinIndex(baseTopUBin.getX() * lf, baseTopUBin.getY() * lf);
+								TileIndex baseTile = new TileIndex(b, 0, 0);
+								for (int rx = 0; rx < lf; ++rx) {
+									for (int ry = 0; ry < lf; ++ry) {
+										BinIndex bin = new BinIndex(baseUBin.getX() + rx, baseUBin.getY() + ry);
+										TileAndBinIndices tbi = TileIndex.universalBinIndexToTileBinIndex(baseTile, bin);
+										TileData<List<Integer>> subTile = allTiles.get(b).get(tbi.getTile());
+										if (null != subTile) {
+											List<Integer> subBin = subTile.getBin(tbi.getBin().getX(), tbi.getBin().getY());
+											actual = addLists(actual, subBin);
+										}
+									}
+								}
+								if (null == expected || 0 == expected.size()) {
+									Assert.assertTrue(null == actual || 0 == actual.size());
+								} else {
+									Assert.assertEquals(expected.size(), actual.size());
+									for (int n = 0; n < expected.size(); ++n)
+										Assert.assertEquals(expected.get(n), actual.get(n));
+								}
+							}
+						}
+					}
+				}
+			}
+		}
 	}
 }

--- a/binning-utilities/src/test/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIOTest.java
+++ b/binning-utilities/src/test/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIOTest.java
@@ -345,7 +345,27 @@ public class HBaseSlicedPyramidIOTest {
 		for (Result rr : scanner) {
 			byte[] key = rr.getRow();
 			String keyName = new String(key);
-			System.out.println(keyName);
+			if (keyName.equals("metadata")) continue;
+			String[] parts = keyName.split(",");
+			int level = Integer.parseInt(parts[0]);
+			while (parts[1].startsWith("0")) parts[1] = parts[1].substring(1);
+			int x = Integer.parseInt(parts[1]);
+			while (parts[2].startsWith("0")) parts[2] = parts[2].substring(1);
+			int y = Integer.parseInt(parts[2]);
+//			if (level > 12) {
+//				int tx = x;
+//				int ty = y;
+//				int tl = level;
+//				while (tl > 12) {
+//					tl--;
+//					tx = (int) Math.floor(tx/2.0);
+//					ty = (int) Math.floor(ty/2.0);
+//				}
+//				if (tx == 1206 && ty == 2556) {
+//					System.out.println(keyName);
+//				}
+//			}
+			if (level > 14) System.out.println(keyName);
 		}
 	}
 
@@ -375,6 +395,137 @@ public class HBaseSlicedPyramidIOTest {
 		return c;
 	}
 
+	private Map<Integer, Map<TileIndex, TileData<List<Integer>>>> data12_1206_2556 (PyramidIO io, TileSerializer<List<Integer>> serializer, String table, int slice) throws Exception {
+		Map<Integer, Map<TileIndex, TileData<List<Integer>>>> result = new HashMap<>();
+		result.put(12, getTileMap(io, serializer, table, slice,
+			                      Arrays.asList(new TileIndex(12, 1206, 2556))));
+		result.put(13, getTileMap(io, serializer, table, slice,
+			                      Arrays.asList(new TileIndex(13,2412,5112),
+									            new TileIndex(13,2412,5113),
+									            new TileIndex(13,2413,5112),
+									            new TileIndex(13,2413,5113))));
+		result.put(14, getTileMap(io, serializer, table, slice,
+			                      Arrays.asList(new TileIndex(14,4824,10224),
+									            new TileIndex(14,4824,10225),
+									            new TileIndex(14,4824,10226),
+									            new TileIndex(14,4824,10227),
+									            new TileIndex(14,4825,10225),
+									            new TileIndex(14,4825,10226),
+									            new TileIndex(14,4825,10227),
+									            new TileIndex(14,4827,10224),
+									            new TileIndex(14,4827,10225),
+									            new TileIndex(14,4827,10226),
+									            new TileIndex(14,4827,10227))));
+
+		return result;
+	}
+
+	private Map<Integer, Map<TileIndex, TileData<List<Integer>>>> dataFull (PyramidIO io, TileSerializer<List<Integer>> serializer, String table, int slice) throws Exception {
+		Map<TileIndex, TileData<List<Integer>>> level8 =
+			getTileMap(io, serializer, table, slice,
+				Arrays.asList(new TileIndex(8, 75, 159)));
+		Map<TileIndex, TileData<List<Integer>>> level9 =
+			getTileMap(io, serializer, table, slice,
+				Arrays.asList(new TileIndex(9, 150, 319), new TileIndex(9, 151, 319)));
+		Map<TileIndex, TileData<List<Integer>>> level10 =
+			getTileMap(io, serializer, table, slice,
+				Arrays.asList(new TileIndex(10, 300, 638), new TileIndex(10, 301, 638),
+					new TileIndex(10, 301, 639), new TileIndex(10, 302, 638),
+					new TileIndex(10, 302, 639)));
+		Map<TileIndex, TileData<List<Integer>>> level11 =
+			getTileMap(io, serializer, table, slice,
+				Arrays.asList(new TileIndex(11, 601, 1276), new TileIndex(11, 601, 1277),
+					new TileIndex(11, 602, 1276), new TileIndex(11, 602, 1277),
+					new TileIndex(11, 602, 1278), new TileIndex(11, 603, 1276),
+					new TileIndex(11, 603, 1277), new TileIndex(11, 603, 1278),
+					new TileIndex(11, 603, 1279), new TileIndex(11, 604, 1276),
+					new TileIndex(11, 604, 1277), new TileIndex(11, 604, 1278),
+					new TileIndex(11, 604, 1279)));
+		Map<TileIndex, TileData<List<Integer>>> level12 =
+			getTileMap(io, serializer, table, slice,
+				Arrays.asList(new TileIndex(12, 1202, 2552), new TileIndex(12, 1202, 2553),
+					new TileIndex(12, 1203, 2552), new TileIndex(12, 1203, 2553),
+					new TileIndex(12, 1203, 2554), new TileIndex(12, 1203, 2555),
+					new TileIndex(12, 1204, 2552), new TileIndex(12, 1204, 2553),
+					new TileIndex(12, 1204, 2554), new TileIndex(12, 1204, 2555),
+					new TileIndex(12, 1205, 2554), new TileIndex(12, 1205, 2555),
+					new TileIndex(12, 1205, 2556), new TileIndex(12, 1206, 2553),
+					new TileIndex(12, 1206, 2554), new TileIndex(12, 1206, 2555),
+					new TileIndex(12, 1206, 2556), new TileIndex(12, 1206, 2557),
+					new TileIndex(12, 1206, 2558), new TileIndex(12, 1207, 2553),
+					new TileIndex(12, 1207, 2554), new TileIndex(12, 1207, 2555),
+					new TileIndex(12, 1207, 2556), new TileIndex(12, 1207, 2557),
+					new TileIndex(12, 1207, 2558), new TileIndex(12, 1208, 2553),
+					new TileIndex(12, 1208, 2554), new TileIndex(12, 1208, 2555),
+					new TileIndex(12, 1208, 2556), new TileIndex(12, 1208, 2557),
+					new TileIndex(12, 1208, 2558), new TileIndex(12, 1209, 2554),
+					new TileIndex(12, 1209, 2555), new TileIndex(12, 1209, 2556)));
+		Map<TileIndex, TileData<List<Integer>>> level13 =
+			getTileMap(io, serializer, table, slice,
+				Arrays.asList(
+					new TileIndex(13, 2405, 5104), new TileIndex(13, 2405, 5105),
+					new TileIndex(13, 2405, 5106), new TileIndex(13, 2406, 5104),
+					new TileIndex(13, 2406, 5105), new TileIndex(13, 2406, 5106),
+					new TileIndex(13, 2406, 5107), new TileIndex(13, 2406, 5108),
+					new TileIndex(13, 2406, 5109), new TileIndex(13, 2407, 5105),
+					new TileIndex(13, 2407, 5106), new TileIndex(13, 2407, 5107),
+					new TileIndex(13, 2407, 5108), new TileIndex(13, 2407, 5109),
+					new TileIndex(13, 2407, 5110), new TileIndex(13, 2408, 5105),
+					new TileIndex(13, 2408, 5106), new TileIndex(13, 2408, 5107),
+					new TileIndex(13, 2408, 5108), new TileIndex(13, 2408, 5109),
+					new TileIndex(13, 2408, 5110), new TileIndex(13, 2409, 5107),
+					new TileIndex(13, 2409, 5108), new TileIndex(13, 2409, 5109),
+					new TileIndex(13, 2409, 5110), new TileIndex(13, 2410, 5108),
+					new TileIndex(13, 2410, 5109), new TileIndex(13, 2410, 5110),
+					new TileIndex(13, 2411, 5108), new TileIndex(13, 2411, 5109),
+					new TileIndex(13, 2411, 5110), new TileIndex(13, 2411, 5111),
+					new TileIndex(13, 2411, 5112), new TileIndex(13, 2411, 5113),
+					new TileIndex(13, 2412, 5107), new TileIndex(13, 2412, 5108),
+					new TileIndex(13, 2412, 5109), new TileIndex(13, 2412, 5110),
+					new TileIndex(13, 2412, 5111), new TileIndex(13, 2412, 5112),
+					new TileIndex(13, 2412, 5113), new TileIndex(13, 2412, 5114),
+					new TileIndex(13, 2412, 5115), new TileIndex(13, 2413, 5107),
+					new TileIndex(13, 2413, 5108), new TileIndex(13, 2413, 5109),
+					new TileIndex(13, 2413, 5110), new TileIndex(13, 2413, 5111),
+					new TileIndex(13, 2413, 5112), new TileIndex(13, 2413, 5113),
+					new TileIndex(13, 2413, 5114), new TileIndex(13, 2413, 5115),
+					new TileIndex(13, 2413, 5116), new TileIndex(13, 2413, 5117),
+					new TileIndex(13, 2414, 5107), new TileIndex(13, 2414, 5109),
+					new TileIndex(13, 2414, 5110), new TileIndex(13, 2414, 5111),
+					new TileIndex(13, 2414, 5112), new TileIndex(13, 2414, 5113),
+					new TileIndex(13, 2414, 5114), new TileIndex(13, 2414, 5115),
+					new TileIndex(13, 2414, 5116), new TileIndex(13, 2414, 5117),
+					new TileIndex(13, 2415, 5107), new TileIndex(13, 2415, 5109),
+					new TileIndex(13, 2415, 5110), new TileIndex(13, 2415, 5111),
+					new TileIndex(13, 2415, 5112), new TileIndex(13, 2415, 5113),
+					new TileIndex(13, 2415, 5114), new TileIndex(13, 2415, 5115),
+					new TileIndex(13, 2415, 5116), new TileIndex(13, 2415, 5117),
+					new TileIndex(13, 2416, 5107), new TileIndex(13, 2416, 5108),
+					new TileIndex(13, 2416, 5109), new TileIndex(13, 2416, 5110),
+					new TileIndex(13, 2416, 5111), new TileIndex(13, 2416, 5112),
+					new TileIndex(13, 2416, 5113), new TileIndex(13, 2416, 5114),
+					new TileIndex(13, 2416, 5115), new TileIndex(13, 2416, 5116),
+					new TileIndex(13, 2416, 5117), new TileIndex(13, 2417, 5107),
+					new TileIndex(13, 2417, 5108), new TileIndex(13, 2417, 5109),
+					new TileIndex(13, 2417, 5110), new TileIndex(13, 2417, 5111),
+					new TileIndex(13, 2417, 5112), new TileIndex(13, 2417, 5113),
+					new TileIndex(13, 2417, 5114), new TileIndex(13, 2418, 5108),
+					new TileIndex(13, 2418, 5109), new TileIndex(13, 2418, 5110),
+					new TileIndex(13, 2418, 5111), new TileIndex(13, 2418, 5112),
+					new TileIndex(13, 2418, 5113)
+				));
+
+		Map<Integer, Map<TileIndex, TileData<List<Integer>>>> allTiles = new HashMap<>();
+		allTiles.put(8, level8);
+		allTiles.put(9, level9);
+		allTiles.put(10, level10);
+		allTiles.put(11, level11);
+		allTiles.put(12, level12);
+		allTiles.put(13, level13);
+
+		return allTiles;
+	}
+
 	// Make sure the various levels match in a weird tile set - i.e., make sure there are no lower-level holes that
 	// don't also exist at upper levels.
 	@Test
@@ -384,57 +535,13 @@ public class HBaseSlicedPyramidIOTest {
 		TileSerializer<List<Integer>> serializer = new KryoSerializer<>(new TypeDescriptor(List.class, new TypeDescriptor(Integer.class)));
 
 		for (int slice = 0; slice < 53; ++slice) {
-			Map<TileIndex, TileData<List<Integer>>> level8 =
-				getTileMap(io, serializer, table, slice,
-					Arrays.asList(new TileIndex(8, 75, 159)));
-			Map<TileIndex, TileData<List<Integer>>> level9 =
-				getTileMap(io, serializer, table, slice,
-					Arrays.asList(new TileIndex(9, 150, 319), new TileIndex(9, 151, 319)));
-			Map<TileIndex, TileData<List<Integer>>> level10 =
-				getTileMap(io, serializer, table, slice,
-					Arrays.asList(new TileIndex(10, 300, 638), new TileIndex(10, 301, 638),
-						new TileIndex(10, 301, 639), new TileIndex(10, 302, 638),
-						new TileIndex(10, 302, 639)));
-			Map<TileIndex, TileData<List<Integer>>> level11 =
-				getTileMap(io, serializer, table, slice,
-					Arrays.asList(new TileIndex(11, 601, 1276), new TileIndex(11, 601, 1277),
-						new TileIndex(11, 602, 1276), new TileIndex(11, 602, 1277),
-						new TileIndex(11, 602, 1278), new TileIndex(11, 603, 1276),
-						new TileIndex(11, 603, 1277), new TileIndex(11, 603, 1278),
-						new TileIndex(11, 603, 1279), new TileIndex(11, 604, 1276),
-						new TileIndex(11, 604, 1277), new TileIndex(11, 604, 1278),
-						new TileIndex(11, 604, 1279)));
-			Map<TileIndex, TileData<List<Integer>>> level12 =
-				getTileMap(io, serializer, table, slice,
-					Arrays.asList(new TileIndex(12, 1202, 2552), new TileIndex(12, 1202, 2553),
-						new TileIndex(12, 1203, 2552), new TileIndex(12, 1203, 2553),
-						new TileIndex(12, 1203, 2554), new TileIndex(12, 1203, 2555),
-						new TileIndex(12, 1204, 2552), new TileIndex(12, 1204, 2553),
-						new TileIndex(12, 1204, 2554), new TileIndex(12, 1204, 2555),
-						new TileIndex(12, 1205, 2554), new TileIndex(12, 1205, 2555),
-						new TileIndex(12, 1205, 2556), new TileIndex(12, 1206, 2553),
-						new TileIndex(12, 1206, 2554), new TileIndex(12, 1206, 2555),
-						new TileIndex(12, 1206, 2556), new TileIndex(12, 1206, 2557),
-						new TileIndex(12, 1206, 2558), new TileIndex(12, 1207, 2553),
-						new TileIndex(12, 1207, 2554), new TileIndex(12, 1207, 2555),
-						new TileIndex(12, 1207, 2556), new TileIndex(12, 1207, 2557),
-						new TileIndex(12, 1207, 2558), new TileIndex(12, 1208, 2553),
-						new TileIndex(12, 1208, 2554), new TileIndex(12, 1208, 2555),
-						new TileIndex(12, 1208, 2556), new TileIndex(12, 1208, 2557),
-						new TileIndex(12, 1208, 2558), new TileIndex(12, 1209, 2554),
-						new TileIndex(12, 1209, 2555), new TileIndex(12, 1209, 2556)));
 
-			Map<Integer, Map<TileIndex, TileData<List<Integer>>>> allTiles = new HashMap<>();
-			allTiles.put(8, level8);
-			allTiles.put(9, level9);
-			allTiles.put(10, level10);
-			allTiles.put(11, level11);
-			allTiles.put(12, level12);
+			for (int t = 8; t < 13; ++t) {
+				Map<Integer, Map<TileIndex, TileData<List<Integer>>>> allTiles = dataFull(io, serializer, table, slice);
 
-			for (int t = 8; t < 12; ++t) {
 				for (TileData<List<Integer>> topTile : allTiles.get(t).values()) {
 					TileIndex topIdx = topTile.getDefinition();
-					for (int b = t + 1; b < 13; ++b) {
+					for (int b = t + 1; b < 14; ++b) {
 						int lf = 1 << (b - t);
 						for (int x = 0; x < 256; ++x) {
 							for (int y = 0; y < 256; ++y) {

--- a/binning-utilities/src/test/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIOTest.java
+++ b/binning-utilities/src/test/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIOTest.java
@@ -196,4 +196,11 @@ public class HBaseSlicedPyramidIOTest {
 			}
 		}
 	}
+
+	@Test
+	public void testSliceDecompositionVsSingleSlices () throws Exception {
+		String table = "hbsioTest";
+		HBaseSlicedPyramidIO io = new HBaseSlicedPyramidIO("hadoop-s1", "2181", "hadoop-s1:60000");
+		TileSerializer<List<Integer>> serializer = new KryoSerializer<>(new TypeDescriptor(List.class, new TypeDescriptor(Integer.class)));
+	}
 }

--- a/tile-generation/build.gradle
+++ b/tile-generation/build.gradle
@@ -125,6 +125,8 @@ dependencies {
 	}
 	compile "org.scala-lang:scala-library:$scalaVersion"
 	compile "org.clapper:grizzled-slf4j_2.10:1.0.2"
+	compile "joda-time:joda-time:2.8.1"
+	compile "org.joda:joda-convert:1.7"
 	compile project(":binning-utilities")
 	compile project(":geometric-utilities")
 	testCompile "org.scalatest:scalatest_$dependencyScalaVersion:2.1.1"

--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/datasets/ValueExtractor.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/datasets/ValueExtractor.scala
@@ -363,7 +363,13 @@ class MeanValueExtractor[T: ClassTag] (field: String, analytic: NumericMeanBinni
 	override def convert: (Seq[Any]) => (T, Int) = s => (s(0).asInstanceOf[T], 1)
 	override def binningAnalytic: BinningAnalytic[(T, Int), JavaDouble] = analytic
 	def getTileAnalytics: Seq[AnalysisDescription[TileData[JavaDouble], _]] = {
-		val convertFcn: JavaDouble => T = bt => numeric.fromDouble(bt.doubleValue())
+		val convertFcn: JavaDouble => T = bt => {
+      if (null == bt) {
+        numeric.fromDouble(analytic.finish(analytic.defaultProcessedValue))
+      } else {
+        numeric.fromDouble(bt.doubleValue())
+      }
+    }
 		Seq(new AnalysisDescriptionTileWrapper[JavaDouble, T](convertFcn, new NumericMinTileAnalytic[T]()),
 		    new AnalysisDescriptionTileWrapper[JavaDouble, T](convertFcn, new NumericMaxTileAnalytic[T]()))
 	}

--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/pipeline/PipelineOperations.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/pipeline/PipelineOperations.scala
@@ -32,7 +32,7 @@ package com.oculusinfo.tilegen.pipeline
 import java.sql.Timestamp
 import java.text.SimpleDateFormat
 import java.util.concurrent.atomic.AtomicInteger
-import java.util.{GregorianCalendar, Date}
+import java.util.{Calendar, GregorianCalendar, Date}
 
 import com.oculusinfo.binning.TileIndex
 import com.oculusinfo.binning.impl.WebMercatorTilePyramid
@@ -42,7 +42,8 @@ import com.oculusinfo.tilegen.util.KeyValueArgumentSource
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{TimestampType, IntegerType}
 import org.apache.spark.sql.{Column, DataFrame, SQLContext}
-
+import org.joda.time.base.BaseSingleFieldPeriod
+import org.joda.time.{Interval, PeriodType, DateTime, DurationFieldType}
 
 
 /**
@@ -212,6 +213,42 @@ object PipelineOperations {
       val calendar = new GregorianCalendar()
       calendar.setTime(date)
       calendar.get(timeField)
+    }
+    val output = SchemaTypeUtilities.addColumn(input.srdd, fieldCol, IntegerType, fieldExtractor, timeCol)
+    PipelineData(input.sqlContext, output)
+  }
+
+  def getJodaTypes (timeField: Int) =
+  timeField match {
+    case Calendar.MILLISECOND          => (PeriodType.millis(), DurationFieldType.millis())
+    case Calendar.SECOND               => (PeriodType.seconds(), DurationFieldType.seconds())
+    case Calendar.MINUTE               => (PeriodType.minutes(), DurationFieldType.minutes())
+    case Calendar.HOUR                 => (PeriodType.hours(), DurationFieldType.hours())
+    case Calendar.HOUR_OF_DAY          => (PeriodType.hours(), DurationFieldType.hours())
+    case Calendar.DAY_OF_WEEK          => (PeriodType.days(), DurationFieldType.days())
+    case Calendar.DAY_OF_WEEK_IN_MONTH => (PeriodType.days(), DurationFieldType.days())
+    case Calendar.DAY_OF_MONTH         => (PeriodType.days(), DurationFieldType.days())
+    case Calendar.DAY_OF_YEAR          => (PeriodType.days(), DurationFieldType.days())
+    case Calendar.WEEK_OF_MONTH        => (PeriodType.weeks(), DurationFieldType.weeks())
+    case Calendar.WEEK_OF_YEAR         => (PeriodType.weeks(), DurationFieldType.weeks())
+    case Calendar.MONTH                => (PeriodType.months(), DurationFieldType.months())
+    case Calendar.YEAR                 => (PeriodType.years(), DurationFieldType.years())
+  }
+  def getIntervalFromJoda (startMoment: Long, currentMoment: Long, intervalType: (PeriodType, DurationFieldType)): Int = {
+    if (currentMoment < startMoment) {
+      -(new Interval(currentMoment, startMoment).toPeriod(intervalType._1).get(intervalType._2))
+    } else {
+      (new Interval(startMoment, currentMoment).toPeriod(intervalType._1).get(intervalType._2))
+    }
+  }
+
+  def elapsedDateOp (timeCol: String, fieldCol: String, timeField: Int, startTime: Date)(input: PipelineData): PipelineData = {
+    val jodaTypes = getJodaTypes(timeField)
+    val startMoment = startTime.getTime
+
+    val fieldExtractor: Array[Any] => Any = row => {
+      val moment = row(0).asInstanceOf[Date].getTime
+      getIntervalFromJoda(startMoment, moment, jodaTypes)
     }
     val output = SchemaTypeUtilities.addColumn(input.srdd, fieldCol, IntegerType, fieldExtractor, timeCol)
     PipelineData(input.sqlContext, output)

--- a/tile-generation/src/test/scala/com/oculusinfo/tilegen/pipeline/PipelineOperationsTests.scala
+++ b/tile-generation/src/test/scala/com/oculusinfo/tilegen/pipeline/PipelineOperationsTests.scala
@@ -699,12 +699,12 @@ class PipelineOperationsTests extends FunSuite with SharedSparkContext with Tile
     val weeks = ListBuffer[Any]()
     val months = ListBuffer[Any]()
     rootStage.addChild(PipelineStage("ConvertDates", parseDateOp("date", "parsedDate", format)(_)))
-             .addChild(PipelineStage("GetDay", dateFieldOp("parsedDate", "day", Calendar.DAY_OF_YEAR)(_)))
-             .addChild(PipelineStage("GetDay", dateFieldOp("parsedDate", "week", Calendar.WEEK_OF_YEAR)(_)))
-             .addChild(PipelineStage("GetDay", dateFieldOp("parsedDate", "month", Calendar.MONTH)(_)))
-             .addChild(new PipelineStage("output", outputOps(List("day"), days)(_)))
-             .addChild(new PipelineStage("output", outputOps(List("week"), weeks)(_)))
-             .addChild(new PipelineStage("output", outputOps(List("month"), months)(_)))
+      .addChild(PipelineStage("GetDay", dateFieldOp("parsedDate", "day", Calendar.DAY_OF_YEAR)(_)))
+      .addChild(PipelineStage("GetDay", dateFieldOp("parsedDate", "week", Calendar.WEEK_OF_YEAR)(_)))
+      .addChild(PipelineStage("GetDay", dateFieldOp("parsedDate", "month", Calendar.MONTH)(_)))
+      .addChild(new PipelineStage("output", outputOps(List("day"), days)(_)))
+      .addChild(new PipelineStage("output", outputOps(List("week"), weeks)(_)))
+      .addChild(new PipelineStage("output", outputOps(List("month"), months)(_)))
     PipelineTree.execute(rootStage, sqlc)
 
     assert((1 to 365).toList === days)
@@ -712,5 +712,45 @@ class PipelineOperationsTests extends FunSuite with SharedSparkContext with Tile
     assert((1 to 53).toList === weeks.map(_.asInstanceOf[Int]).toSet.toList.sorted)
     // months are zero-based for some reason
     assert((0 to 11).toList === months.map(_.asInstanceOf[Int]).toSet.toList.sorted)
+  }
+
+  test("Test elapsed date field extraction") {
+    val format = "yyyy DD"
+    def createDataOp(count: Int)(input: PipelineData) = {
+      val formatter = new SimpleDateFormat(format)
+      val pyramid = new WebMercatorTilePyramid
+      val jsonData = (1 to 365).map{day =>
+        val date = new GregorianCalendar()
+        date.set(Calendar.YEAR, 2000)
+        date.set(Calendar.DAY_OF_YEAR, day)
+        val formattedDate = formatter.format(date.getTime)
+        s"""{"x": $day, "y": 1, "date": "$formattedDate"}"""
+      }
+
+      val srdd = sqlc.jsonRDD(sc.parallelize(jsonData))
+      PipelineData(sqlc, srdd)
+    }
+
+    val rootStage = PipelineStage("create_data", createDataOp(8)(_))
+    val days = ListBuffer[Any]()
+    val weeks = ListBuffer[Any]()
+    val months = ListBuffer[Any]()
+    rootStage.addChild(PipelineStage("ConvertDates", parseDateOp("date", "parsedDate", format)(_)))
+      .addChild(PipelineStage("GetDay", elapsedDateOp("parsedDate", "day", Calendar.DAY_OF_YEAR,
+                                                      new GregorianCalendar(2000, 0, 5).getTime)(_)))
+      .addChild(PipelineStage("GetDay", elapsedDateOp("parsedDate", "week", Calendar.WEEK_OF_YEAR,
+                                                      new GregorianCalendar(2000, 0, 15).getTime)(_)))
+      .addChild(PipelineStage("GetDay", elapsedDateOp("parsedDate", "month", Calendar.MONTH,
+                                                      new GregorianCalendar(2000, 2, 1).getTime)(_)))
+      .addChild(new PipelineStage("output", outputOps(List("day"), days)(_)))
+      .addChild(new PipelineStage("output", outputOps(List("week"), weeks)(_)))
+      .addChild(new PipelineStage("output", outputOps(List("month"), months)(_)))
+    PipelineTree.execute(rootStage, sqlc)
+
+    assert((-4 to 360).toList === days)
+    // 2000 has 53 weeks - only one day in the first week.
+    assert((-2 to 50).toList === weeks.map(_.asInstanceOf[Int]).toSet.toList.sorted)
+    // months are zero-based for some reason
+    assert((-2 to 9).toList === months.map(_.asInstanceOf[Int]).toSet.toList.sorted)
   }
 }


### PR DESCRIPTION
Slice bucketted tiles in a bucket pyramid, and store the slices as separate sub-columns in HBase.
Allow reading my arbitrary sub-ranges, rather than forcing readers to get back the whole tile.