### PR TITLE
Feature/new slice data format client server

### DIFF
--- a/binning-utilities/src/main/java/com/oculusinfo/binning/impl/DenseTileMultiSliceView.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/impl/DenseTileMultiSliceView.java
@@ -135,23 +135,17 @@ public class DenseTileMultiSliceView<T> implements TileData<List<T>> {
 
 	public TileData<List<T>> harden () {
 		TileIndex index = getDefinition();
+		TileData<List<T>> hardened;
 		if (isDense()) {
-			DenseTileData<List<T>> hardened = new DenseTileData<>(index);
-			hardened.setDefaultValue(_base.getDefaultValue());
+			hardened = new DenseTileData<List<T>>(index, _base.getDefaultValue());
 
 			for (int x=0; x<index.getXBins(); ++x) {
 				for (int y=0; y<index.getYBins(); ++y) {
 					hardened.setBin(x, y, getBin(x, y));
 				}
 			}
-
-			for (String prop: _base.getMetaDataProperties()) {
-				hardened.setMetaData(prop, _base.getMetaData(prop));
-			}
-
-			return hardened;
 		} else {
-			SparseTileData<List<T>> hardened = new SparseTileData<>(index, _base.getDefaultValue());
+			hardened = new SparseTileData<>(index, _base.getDefaultValue());
 
 			for (int x=0; x<index.getXBins(); ++x) {
 				for (int y=0; y<index.getYBins(); ++y) {
@@ -161,13 +155,13 @@ public class DenseTileMultiSliceView<T> implements TileData<List<T>> {
 					}
 				}
 			}
-
-			for (String prop: _base.getMetaDataProperties()) {
-				hardened.setMetaData(prop, _base.getMetaData(prop));
-			}
-
-			return hardened;
 		}
+
+		for (String prop: _base.getMetaDataProperties()) {
+			hardened.setMetaData(prop, _base.getMetaData(prop));
+		}
+
+		return hardened;
 	}
 
 	@Override

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/impl/DenseTileMultiSliceView.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/impl/DenseTileMultiSliceView.java
@@ -145,6 +145,10 @@ public class DenseTileMultiSliceView<T> implements TileData<List<T>> {
 				}
 			}
 
+			for (String prop: _base.getMetaDataProperties()) {
+				hardened.setMetaData(prop, _base.getMetaData(prop));
+			}
+
 			return hardened;
 		} else {
 			SparseTileData<List<T>> hardened = new SparseTileData<>(index, _base.getDefaultValue());
@@ -156,6 +160,10 @@ public class DenseTileMultiSliceView<T> implements TileData<List<T>> {
 						hardened.setBin(x, y, getBin(x, y));
 					}
 				}
+			}
+
+			for (String prop: _base.getMetaDataProperties()) {
+				hardened.setMetaData(prop, _base.getMetaData(prop));
 			}
 
 			return hardened;

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/impl/FilterTileBucketView.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/impl/FilterTileBucketView.java
@@ -27,6 +27,7 @@ package com.oculusinfo.binning.impl;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import com.oculusinfo.binning.TileData;
@@ -113,6 +114,10 @@ public class FilterTileBucketView<T> implements TileData<List<T>> {
 		}
 
 		List<T> binContents = _base.getBin(x, y);
+		if (binContents == null) {
+			binContents = Collections.emptyList();
+		}
+
 		int binSize = binContents.size();
 		
 		// if the bucket range falls outside of the available bin range, return empty list.  null values assume full range

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/impl/MultiSliceTileView.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/impl/MultiSliceTileView.java
@@ -83,7 +83,7 @@ public class MultiSliceTileView<T> implements TileData<List<T>> {
 			if (null == componentBin)
 				// Because we don't know the standard bin length of each component, if any are null, we have to give
 				// up.
-				return null;
+				return Collections.emptyList();
 			else
 				binValue.addAll(componentBin);
 		}

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/AvgDivSliceTileTransformer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/AvgDivSliceTileTransformer.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2015 Uncharted Software.
+ * http://www.oculusinfo.com/
+ *
+ * Released under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package com.oculusinfo.tile.rendering.transformations.tile;
+
+
+import com.oculusinfo.binning.TileData;
+import com.oculusinfo.binning.impl.AverageTileBucketView;
+import com.oculusinfo.binning.impl.BinaryOperationTileView;
+import com.oculusinfo.binning.impl.UnaryOperationTileView;
+import com.oculusinfo.binning.util.BinaryOperator;
+import com.oculusinfo.binning.util.UnaryOperator;
+import com.oculusinfo.factory.ConfigurationException;
+import com.oculusinfo.factory.util.Pair;
+import com.oculusinfo.tile.rendering.LayerConfiguration;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+
+/**
+ * 	This transformer takes in a range of buckets centered on val V, takes their average, and divides them by the average
+ * 	of another range of buckets centered on val V.  The numerator range can be varied externally, while the denominator
+ * 	range is fixed.  Log10 of the final result is returned.
+ */
+public class AvgDivSliceTileTransformer<T extends Number> implements TileTransformer<List<T>> {
+	private static final Logger LOGGER = LoggerFactory.getLogger( AvgDivSliceTileTransformer.class );
+
+	protected Integer _averageRange = 0;
+	protected Integer _startBucket = 0;
+	protected Integer _endBucket = 0;
+	protected Integer _maxBuckets = 0;
+
+	public AvgDivSliceTileTransformer(JSONObject arguments){
+		if ( arguments != null ) {
+			// get the start and end time range
+			_averageRange = arguments.optInt("averageRange");
+			_startBucket = arguments.optInt("startBucket");
+			_endBucket = arguments.optInt("endBucket");
+		} else {
+			LOGGER.warn("No arguments passed in to filterbucket transformer");
+		}
+	}
+
+	public void setMaxBuckets(int maxBuckets) {
+		_maxBuckets = maxBuckets;
+	}
+
+	public int getAverageRange() { return _averageRange; }
+
+	@Override
+	public JSONObject transform (JSONObject inputJSON) throws JSONException {
+		return inputJSON; // not implemented
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see com.oculusinfo.tile.rendering.transformations.tile.TileTransformer#transform(com.oculusinfo.binning.TileData)
+	 *
+	 * Note: This transformer explicitly transforms all tiles into a dense tile format.  If a sparse tile is
+	 * 			passed in, the values not explicitly represented will be set to null.
+	 */
+	@Override
+	public TileData<List<T>> transform (TileData<List<T>> inputData) throws Exception {
+		int numeratorSize = Math.min(_averageRange/2, _endBucket - _startBucket);
+		int middle = _averageRange / 2;
+		int numeratorStart = middle - (numeratorSize / 2);
+		int numeratorEnd = numeratorStart + numeratorSize;
+
+		// Divide average 1 by average 2 and apply log10 to the result.
+		AverageTileBucketView<T> numerator = new AverageTileBucketView<>(inputData, numeratorStart, numeratorEnd);
+		AverageTileBucketView<T> denominator = new AverageTileBucketView<>(inputData, 0, _averageRange);
+		BinaryOperationTileView<T> binaryOpView = new BinaryOperationTileView<>(
+			numerator, denominator, BinaryOperator.OPERATOR_TYPE.DIVIDE, 1.0);
+		return new UnaryOperationTileView<>(UnaryOperator.OPERATOR_TYPE.LOG_10, binaryOpView, -(Math.log10(_averageRange)));
+	}
+
+	@Override
+	public Pair<Double, Double> getTransformedExtrema(LayerConfiguration config) throws ConfigurationException {
+		double ext = Math.log10(_averageRange);
+		return new Pair<>(-ext, ext);
+	}
+}

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/BucketTileTransformer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/BucketTileTransformer.java
@@ -94,6 +94,14 @@ public abstract class BucketTileTransformer<T> implements TileTransformer<List<T
 		return new Pair<>(minimumValue, maximumValue);
 	}
 
+	public Integer getStartBucket() {
+		return _startBucket;
+	}
+
+	public Integer getEndBucket() {
+		return _endBucket;
+	}
+
 	/**
 	 * Extracts the extremum for a level from its LayerConfig
 	 */

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/BucketTileTransformer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/BucketTileTransformer.java
@@ -55,8 +55,6 @@ public abstract class BucketTileTransformer<T> implements TileTransformer<List<T
 			// get the start and end time range
 			_startBucket = arguments.optInt("startBucket");
 			_endBucket = arguments.optInt("endBucket");
-		} else {
-			LOGGER.warn("No arguments passed in to transformer " + getClass().getSimpleName());
 		}
 	}
 
@@ -92,14 +90,6 @@ public abstract class BucketTileTransformer<T> implements TileTransformer<List<T
 			}
 		}
 		return new Pair<>(minimumValue, maximumValue);
-	}
-
-	public Integer getStartBucket() {
-		return _startBucket;
-	}
-
-	public Integer getEndBucket() {
-		return _endBucket;
 	}
 
 	/**

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/IdentityTileTransformer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/IdentityTileTransformer.java
@@ -35,6 +35,8 @@ import com.oculusinfo.binning.TileData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
+
 
 /**
  * A TileTransformer is an interface that can take a JSON representation of
@@ -44,9 +46,11 @@ import org.slf4j.LoggerFactory;
  *
  * @author tlachapelle
  */
-public class IdentityTileTransformer<T> implements TileTransformer<T> {
+public class IdentityTileTransformer<T> extends BucketTileTransformer<T> {
 
-	private static final Logger LOGGER = LoggerFactory.getLogger(IdentityTileTransformer.class);
+	public IdentityTileTransformer(JSONObject arguments) {
+		super(arguments);
+	}
 
 	/**
 	 * Transforms the tile data in JSON format based on transform type and returns result
@@ -65,26 +69,8 @@ public class IdentityTileTransformer<T> implements TileTransformer<T> {
 	 * @throws Exception
 	 */
 	//takes tile data x returns tile data x generified on function level
-	public TileData<T> transform(TileData<T> data) throws Exception {
+	public TileData<List<T>> transform(TileData<List<T>> data) throws Exception {
 		return data;
-	}
-
-	@Override
-	public Pair<Double, Double> getTransformedExtrema(LayerConfiguration config) throws ConfigurationException {
-		String layer = config.getPropertyValue(LayerConfiguration.LAYER_ID);
-		double minimumValue = parseExtremum(config, LayerConfiguration.LEVEL_MINIMUMS, "minimum", layer, 0.0);
-		double maximumValue = parseExtremum(config, LayerConfiguration.LEVEL_MAXIMUMS, "maximum", layer, 1000.0);
-		return new Pair<>(minimumValue,  maximumValue);
-	}
-
-	private double parseExtremum (LayerConfiguration parameter, StringProperty property, String propName, String layer, double def) {
-		String rawValue = parameter.getPropertyValue(property);
-		try {
-			return Double.parseDouble(rawValue);
-		} catch (NumberFormatException|NullPointerException e) {
-			LOGGER.warn("Bad "+propName+" value "+rawValue+" for "+layer+", defaulting to "+def);
-			return def;
-		}
 	}
 }
 

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/TileTransformerFactory.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/TileTransformerFactory.java
@@ -93,7 +93,8 @@ public class TileTransformerFactory extends ConfigurableFactory<TileTransformer<
 			JSONObject arguments = getPropertyValue(INITIALIZATION_DATA);
 			return new AvgLogBucketTileTransformer<>(arguments);
 		} else {  // 'identity' or none passed in will give the default transformer
-			return new IdentityTileTransformer<Object>();
+			JSONObject arguments = getPropertyValue(INITIALIZATION_DATA);
+			return new IdentityTileTransformer<>(arguments);
 		}
 	}
 }

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/TileTransformerFactory.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/TileTransformerFactory.java
@@ -92,6 +92,9 @@ public class TileTransformerFactory extends ConfigurableFactory<TileTransformer<
 		} else if ("avglogbucket".equals(transformerTypes)) {
 			JSONObject arguments = getPropertyValue(INITIALIZATION_DATA);
 			return new AvgLogBucketTileTransformer<>(arguments);
+		} else if ("avgdivslice".equals(transformerTypes)) {
+			JSONObject arguments = getPropertyValue(INITIALIZATION_DATA);
+			return new AvgDivSliceTileTransformer<>(arguments);
 		} else {  // 'identity' or none passed in will give the default transformer
 			JSONObject arguments = getPropertyValue(INITIALIZATION_DATA);
 			return new IdentityTileTransformer<>(arguments);

--- a/tile-service/src/main/java/com/oculusinfo/tile/rest/tile/TileServiceImpl.java
+++ b/tile-service/src/main/java/com/oculusinfo/tile/rest/tile/TileServiceImpl.java
@@ -149,7 +149,12 @@ public class TileServiceImpl implements TileService {
 
 			String bracket = "[0]";
 			if (start != null && end != null) {
-				if (end > start) {
+				if (start == 0 && end == numBuckets - 1) {
+					// If this is uncommented, it will allow us to redirect to a table created as a single bucket,
+					// giving us a big boost in fetch times.
+					// bracket = "__all__";
+					bracket = "";
+				} else if (end > start) {
 					bracket = "[" + start + "-" + end + "]";
 				} else {
 					bracket = "[" + start + "]";

--- a/tile-service/src/main/java/com/oculusinfo/tile/rest/tile/TileServiceImpl.java
+++ b/tile-service/src/main/java/com/oculusinfo/tile/rest/tile/TileServiceImpl.java
@@ -157,7 +157,7 @@ public class TileServiceImpl implements TileService {
 					bracket = "[" + start + "]";
 				}
 			}
-			tileDatas = pyramidIO.readTiles(dataId + bracket, serializer, Collections.singleton(scaleLevelIndex), tileProperties);
+			tileDatas = pyramidIO.readTiles(dataId + bracket, serializer, Collections.singleton(scaleLevelIndex));
 		} else {
 			tileDatas = pyramidIO.readTiles(dataId, serializer, Collections.singleton( scaleLevelIndex ), tileProperties);
 		}


### PR DESCRIPTION
A *very* temporary change to allow the server to work with the new column-qualified hbase IO.  Tile requests are now intercepted in TileServiceImpl, and have their table name decorated with the slice notation used by the new sliced hbase IO.  Additional work was required to get the delta plots functionality to work with the IO as well - a new tile transformed referenced as "avgdivslice" in the json config files must be used for the functionality to work.

Functionality for loading an alternate table when all data is requested is currently commented out in TileServiceImpl, as there was an issue with tile generation.  We need to be able to generate a tile set that uses the sliced hbase IO, but only consists of one slice that covers the entire data range.  That is not currently supported in the TwitterTimeHeatmapPipeline app.