### PR TITLE
Add OpenCSV library to assembly build and refactor CSV record parser

### DIFF
--- a/tile-generation/build.gradle
+++ b/tile-generation/build.gradle
@@ -149,6 +149,7 @@ dependencies {
 	assemblyJarReq project (":factory-utilities")
 	assemblyJarReq "org.json:json:20090211"
 	assemblyJarReq "org.clapper:grizzled-slf4j_2.10:1.0.2"
+	assemblyJarReq "com.opencsv:opencsv:3.4"
 	addHBaseDependencies("assemblyJarReq")
 }
 

--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/datasets/CSVReader.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/datasets/CSVReader.scala
@@ -141,14 +141,10 @@ class CSVReader (val sqlc: SQLContext, data: RDD[String], configuration: KeyValu
 		val rowRDD: RDD[Row] = data.map(record =>
 			Try{
 
-        def getFields(line : String) = {
-          if (quotechar.isEmpty) {
-            val parser = new CSVParser(separator.charAt(0))
-            parser.parseLine(line)
-          } else {
-            val parser = new CSVParser(separator.charAt(0), quotechar.charAt(0))
-            parser.parseLine(line)
-          }
+        def getFields (line: String) = {
+          val parser = new CSVParser(separator.charAt(0),
+            Try(quotechar.charAt(0)).getOrElse(CSVParser.DEFAULT_QUOTE_CHARACTER))
+          parser.parseLine(line)
         }
 
 				val fields = getFields(record)


### PR DESCRIPTION
- Add OpenCSV library to assembly build.
- Refactor internal record parser function to make the use of the quote char more obvious.