### PR TITLE
Make cloning and overlaying more resilient in the face of missing object and array data

### DIFF
--- a/binning-utilities/src/main/java/com/oculusinfo/binning/util/JsonUtilities.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/util/JsonUtilities.java
@@ -60,7 +60,7 @@ public class JsonUtilities {
 			String[] keys = JSONObject.getNames(source);
 			if (null != keys) {
 				for (String key: keys) {
-					Object value = source.get(key);
+					Object value = source.opt(key);
 					if (value instanceof JSONObject) {
 						JSONObject valueClone = deepClone((JSONObject) value);
 						clone.put(key, valueClone);
@@ -89,7 +89,7 @@ public class JsonUtilities {
 			JSONArray clone = new JSONArray();
 			for (int i=0; i<source.length(); ++i) {
 				if (!source.isNull(i)) {
-					Object value = source.get(i);
+					Object value = source.opt(i);
 					if (value instanceof JSONObject) {
 						JSONObject valueClone = deepClone((JSONObject) value);
 						clone.put(i, valueClone);
@@ -121,7 +121,7 @@ public class JsonUtilities {
 
 		try {
 			for (String key: JSONObject.getNames(overlay)) {
-				Object value = overlay.get(key);
+				Object value = overlay.opt(key);
 				if (value instanceof JSONObject) {
 					if (base.has(key) && base.get(key) instanceof JSONObject) {
 						overlayInPlace((JSONObject) base.get(key), (JSONObject) value);
@@ -140,7 +140,7 @@ public class JsonUtilities {
 			}
 			return base;
 		} catch (JSONException e) {
-			LOGGER.error("Weird JSON exception cloning object", e);
+			LOGGER.error("Weird JSON exception overlaying object", e);
 			return null;
 		}
 	}
@@ -250,7 +250,7 @@ public class JsonUtilities {
 
 			// Overlay elements in both or just in the overlay
 			for (int i=0; i<overlay.length(); ++i) {
-				Object value = overlay.get(i);
+				Object value = overlay.opt(i);
 				if (JSON_NULL.equals(value)) {
 					// Null array element; ignore, don't everlay
 					Object baseValue = base.get(i);
@@ -280,7 +280,7 @@ public class JsonUtilities {
 
 			return result;
 		} catch (JSONException e) {
-			LOGGER.error("Weird JSON exception cloning object", e);
+			LOGGER.error("Weird JSON exception overlaying object", e);
 			return null;
 		}
 	}


### PR DESCRIPTION
.get throws an error for missing data
.opt just returns null.
.opt is fine, so I changed to it.
Also fixed some copy-and-paste errors in error messages while I was at it.