### PR TITLE
Remove development-only server override

### DIFF
--- a/tile-examples/julia-demo-live/src/main/webapp/WEB-INF/web.xml
+++ b/tile-examples/julia-demo-live/src/main/webapp/WEB-INF/web.xml
@@ -4,19 +4,8 @@
 
 <web-app>
 	<display-name>Data Tile Server</display-name>
-
-	<!-- stop windows from memory mapping the files, which locks them -->
-	<servlet>
-	    <servlet-name>default</servlet-name>
-	    <servlet-class>org.mortbay.jetty.servlet.DefaultServlet</servlet-class>
-	    <init-param>
-	      	<param-name>useFileMappedBuffer</param-name>
-	      	<param-value>false</param-value>
-	    </init-param>
-	    <load-on-startup>0</load-on-startup>
-  	</servlet>
-
-	<!-- Module Configuration -->
+  
+  <!-- Module Configuration -->
 	<!-- If you have your own Guice module(s), put them here as a colon-separated
 	     list. -->
 	<context-param>

--- a/tile-examples/julia-demo/src/main/webapp/WEB-INF/web.xml
+++ b/tile-examples/julia-demo/src/main/webapp/WEB-INF/web.xml
@@ -5,17 +5,6 @@
 <web-app>
 	<display-name>Data Tile Server</display-name>
 
-	<!-- stop windows from memory mapping the files, which locks them -->
-	<servlet>
-	    <servlet-name>default</servlet-name>
-	    <servlet-class>org.mortbay.jetty.servlet.DefaultServlet</servlet-class>
-	    <init-param>
-	      	<param-name>useFileMappedBuffer</param-name>
-	      	<param-value>false</param-value>
-	    </init-param>
-	    <load-on-startup>0</load-on-startup>
-  	</servlet>
-
 	<!-- Module Configuration -->
 	<!-- If you have your own Guice module(s), put them here as a colon-separated
 	     list. -->

--- a/tile-examples/twitter-topics/twitter-topics-client/src/main/webapp/WEB-INF/web.xml
+++ b/tile-examples/twitter-topics/twitter-topics-client/src/main/webapp/WEB-INF/web.xml
@@ -4,19 +4,8 @@
 
 <web-app>
 	<display-name>Data Tile Server</display-name>
-
-	<!-- stop windows from memory mapping the files, which locks them -->
-	<servlet>
-	    <servlet-name>default</servlet-name>
-	    <servlet-class>org.mortbay.jetty.servlet.DefaultServlet</servlet-class>
-	    <init-param>
-	      	<param-name>useFileMappedBuffer</param-name>
-	      	<param-value>false</param-value>
-	    </init-param>
-	    <load-on-startup>0</load-on-startup>
-  	</servlet>
-
-	<!-- Module Configuration -->
+  
+  <!-- Module Configuration -->
 	<!-- If you have your own Guice module(s), put them here as a colon-separated
 	     list. -->
 	<context-param>


### PR DESCRIPTION
We configure Jetty to disable memory mapped files, since that results in them being locked under Windows and breaks front-end dev workflow.  That workaround isn't necessary in the examples distribution.

resolves #233 
