### PR TITLE
Make configuration errors more apparent.

### DIFF
--- a/binning-utilities/src/main/java/com/oculusinfo/binning/TilePyramidFactory.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/TilePyramidFactory.java
@@ -27,6 +27,7 @@ package com.oculusinfo.binning;
 import com.oculusinfo.binning.impl.AOITilePyramid;
 import com.oculusinfo.binning.impl.WebMercatorTilePyramid;
 import com.oculusinfo.factory.ConfigurableFactory;
+import com.oculusinfo.factory.ConfigurationException;
 import com.oculusinfo.factory.properties.DoubleProperty;
 import com.oculusinfo.factory.properties.StringProperty;
 
@@ -70,7 +71,7 @@ public class TilePyramidFactory extends ConfigurableFactory<TilePyramid> {
 	}
 
 	@Override
-	protected TilePyramid create () {
+	protected TilePyramid create () throws ConfigurationException {
 		String pyramidType = getPropertyValue(PYRAMID_TYPE).toLowerCase();
 
 		if ("webmercator".equals(pyramidType) || "epsg:900913".equals(pyramidType) || "epsg:3857".equals(pyramidType)) {
@@ -82,7 +83,7 @@ public class TilePyramidFactory extends ConfigurableFactory<TilePyramid> {
 			double maxY = getPropertyValue(MAXIMUM_Y);
 			return new AOITilePyramid(minX, minY, maxX, maxY);
 		} else {
-			return null;
+			throw new ConfigurationException("Unrecognized pyramid type "+pyramidType);
 		}
 	}
 }

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/DummyPyramidIOFactory.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/DummyPyramidIOFactory.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import com.oculusinfo.binning.io.PyramidIO;
 import com.oculusinfo.factory.ConfigurableFactory;
+import com.oculusinfo.factory.ConfigurationException;
 import com.oculusinfo.factory.properties.DoubleProperty;
 import com.oculusinfo.factory.properties.IntegerProperty;
 
@@ -53,7 +54,7 @@ public class DummyPyramidIOFactory extends ConfigurableFactory<PyramidIO> {
 	}
 
 	@Override
-	protected PyramidIO create() {
+	protected PyramidIO create() throws ConfigurationException {
 		double minX = getPropertyValue(MIN_X);
 		double maxX = getPropertyValue(MAX_X);
 		double minY = getPropertyValue(MIN_Y);

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/ElasticsearchPyramidIOFactory.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/ElasticsearchPyramidIOFactory.java
@@ -3,6 +3,7 @@ package com.oculusinfo.binning.io.impl;
 import com.oculusinfo.binning.TilePyramid;
 import com.oculusinfo.binning.io.PyramidIO;
 import com.oculusinfo.factory.ConfigurableFactory;
+import com.oculusinfo.factory.ConfigurationException;
 import com.oculusinfo.factory.SharedInstanceFactory;
 import com.oculusinfo.factory.properties.IntegerProperty;
 import com.oculusinfo.factory.properties.StringProperty;
@@ -64,27 +65,20 @@ public class ElasticsearchPyramidIOFactory extends SharedInstanceFactory<Pyramid
 	}
 
 	@Override
-	protected PyramidIO createInstance() {
-		try{
-			LOGGER.info("ES pyramid factory.");
+	protected PyramidIO createInstance() throws ConfigurationException {
+		LOGGER.info("ES pyramid factory.");
 
-			String clusterName = getPropertyValue(ES_CLUSTER_NAME);
-			String transportAddress = getPropertyValue(ES_TRANSPORT_ADDRESS);
-			int transportPort = getPropertyValue(ES_TRANSPORT_PORT);
+		String clusterName = getPropertyValue(ES_CLUSTER_NAME);
+		String transportAddress = getPropertyValue(ES_TRANSPORT_ADDRESS);
+		int transportPort = getPropertyValue(ES_TRANSPORT_PORT);
 
-			Integer numZoomLevels = getPropertyValue(NUM_ZOOM_LEVELS);
+		Integer numZoomLevels = getPropertyValue(NUM_ZOOM_LEVELS);
 
-			String elasticIndex = getPropertyValue(ES_INDEX);
-			String esFieldX = getPropertyValue(ES_FIELD_X);
-			String esFieldY = getPropertyValue(ES_FIELD_Y);
-			TilePyramid tilePyramid = getRoot().produce( TilePyramid.class );
+		String elasticIndex = getPropertyValue(ES_INDEX);
+		String esFieldX = getPropertyValue(ES_FIELD_X);
+		String esFieldY = getPropertyValue(ES_FIELD_Y);
+		TilePyramid tilePyramid = getRoot().produce(TilePyramid.class);
 
-			return new ElasticsearchPyramidIO(clusterName, elasticIndex, esFieldX, esFieldY, transportAddress, transportPort, tilePyramid, numZoomLevels );
-
-		}catch (Exception e){
-			LOGGER.error("Error creating ES pyramidio", e);
-		}
-
-		return null;
+		return new ElasticsearchPyramidIO(clusterName, elasticIndex, esFieldX, esFieldY, transportAddress, transportPort, tilePyramid, numZoomLevels);
 	}
 }

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/FileBasedPyramidIOFactory.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/FileBasedPyramidIOFactory.java
@@ -26,6 +26,7 @@ package com.oculusinfo.binning.io.impl;
 
 import com.oculusinfo.binning.io.PyramidIO;
 import com.oculusinfo.factory.ConfigurableFactory;
+import com.oculusinfo.factory.ConfigurationException;
 import com.oculusinfo.factory.properties.StringProperty;
 
 import org.slf4j.Logger;
@@ -62,33 +63,27 @@ public class FileBasedPyramidIOFactory extends ConfigurableFactory<PyramidIO> {
 
 
 	@Override
-	protected PyramidIO create() {
-		try {
-			String rootpath = getPropertyValue(ROOT_PATH).trim();
-			String extension = getPropertyValue(EXTENSION);
-			PyramidSource source = null;
-			
-			if (rootpath.endsWith(".zip")) {
-				// currently only handle zip, can expand to others (tar, rar, etc...)
-				// We need a cache of zip sources - they are slow to read.
-				source = ZipResourcePyramidSource.getZipSource(rootpath, extension);					
-			} else if (rootpath.startsWith("file://")) {
-				// a file/directory on the file system
-				rootpath = rootpath.substring(7);
-				source = new FileSystemPyramidSource(rootpath, extension); 
-			} else if (rootpath.startsWith("res://")) {
-				// a file/directory within the webapp resources
-				rootpath = rootpath.substring(6);
-				source = new ResourcePyramidSource(rootpath, extension);
-			} else {
-				// no prefix / postfix supplied, default to file for legacy support
-				source = new FileSystemPyramidSource(rootpath, extension);
-			}
-			return new FileBasedPyramidIO(source);
+	protected PyramidIO create() throws ConfigurationException {
+		String rootpath = getPropertyValue(ROOT_PATH).trim();
+		String extension = getPropertyValue(EXTENSION);
+		PyramidSource source = null;
+
+		if (rootpath.endsWith(".zip")) {
+			// currently only handle zip, can expand to others (tar, rar, etc...)
+			// We need a cache of zip sources - they are slow to read.
+			source = ZipResourcePyramidSource.getZipSource(rootpath, extension);
+		} else if (rootpath.startsWith("file://")) {
+			// a file/directory on the file system
+			rootpath = rootpath.substring(7);
+			source = new FileSystemPyramidSource(rootpath, extension);
+		} else if (rootpath.startsWith("res://")) {
+			// a file/directory within the webapp resources
+			rootpath = rootpath.substring(6);
+			source = new ResourcePyramidSource(rootpath, extension);
+		} else {
+			// no prefix / postfix supplied, default to file for legacy support
+			source = new FileSystemPyramidSource(rootpath, extension);
 		}
-		catch (Exception e) {
-			LOGGER.error("Error trying to create FileBasedPyramidIO", e);
-		}
-		return null;
+		return new FileBasedPyramidIO(source);
 	}
 }

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/HBasePyramidIOFactory.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/HBasePyramidIOFactory.java
@@ -25,12 +25,14 @@ package com.oculusinfo.binning.io.impl;
 
 import com.oculusinfo.binning.io.PyramidIO;
 import com.oculusinfo.factory.ConfigurableFactory;
+import com.oculusinfo.factory.ConfigurationException;
 import com.oculusinfo.factory.SharedInstanceFactory;
 import com.oculusinfo.factory.properties.StringProperty;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.List;
 
 
@@ -57,16 +59,14 @@ public class HBasePyramidIOFactory extends SharedInstanceFactory<PyramidIO> {
 	}
 
 	@Override
-	protected PyramidIO createInstance () {
+	protected PyramidIO createInstance () throws ConfigurationException {
 		try {
 			String quorum = getPropertyValue(HBASE_ZOOKEEPER_QUORUM);
 			String port = getPropertyValue(HBASE_ZOKEEPER_PORT);
 			String master = getPropertyValue(HBASE_MASTER);
 			return new HBasePyramidIO(quorum, port, master);
+		} catch (IOException e) {
+			throw new ConfigurationException("Exception creating HBase pyramid IO", e);
 		}
-		catch (Exception e) {
-			LOGGER.error("Error trying to create HBasePyramidIO", e);
-		}
-		return null;
 	}
 }

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIOFactory.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/HBaseSlicedPyramidIOFactory.java
@@ -25,11 +25,13 @@ package com.oculusinfo.binning.io.impl;
 
 import com.oculusinfo.binning.io.PyramidIO;
 import com.oculusinfo.factory.ConfigurableFactory;
+import com.oculusinfo.factory.ConfigurationException;
 import com.oculusinfo.factory.SharedInstanceFactory;
 import com.oculusinfo.factory.properties.StringProperty;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.List;
 
 public class HBaseSlicedPyramidIOFactory extends SharedInstanceFactory<PyramidIO> {
@@ -45,17 +47,15 @@ public class HBaseSlicedPyramidIOFactory extends SharedInstanceFactory<PyramidIO
 	}
 
 	@Override
-	protected PyramidIO createInstance () {
+	protected PyramidIO createInstance () throws ConfigurationException {
 		try {
 			String quorum = getPropertyValue(HBasePyramidIOFactory.HBASE_ZOOKEEPER_QUORUM);
 			String port = getPropertyValue(HBasePyramidIOFactory.HBASE_ZOKEEPER_PORT);
 			String master = getPropertyValue(HBasePyramidIOFactory.HBASE_MASTER);
 			return new HBaseSlicedPyramidIO(quorum, port, master);
+		} catch (IOException e) {
+			throw new ConfigurationException("Error creating HBase sliced pyramid IO", e);
 		}
-		catch (Exception e) {
-			LOGGER.error("Error trying to create HBaseSlicedPyramidIO", e);
-		}
-		return null;
 	}
 }
 

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/JDBCPyramidIO.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/JDBCPyramidIO.java
@@ -62,7 +62,7 @@ public class JDBCPyramidIO implements PyramidIO {
 
 	private Connection _connection;
 
-	public JDBCPyramidIO(String driverClassName, String dbUrl) throws Exception {
+	public JDBCPyramidIO(String driverClassName, String dbUrl) throws ClassNotFoundException, SQLException {
 		Class.forName(driverClassName);
 		_connection = DriverManager.getConnection(dbUrl);
 	}

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/JDBCPyramidIOFactory.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/JDBCPyramidIOFactory.java
@@ -26,11 +26,13 @@ package com.oculusinfo.binning.io.impl;
 
 import com.oculusinfo.binning.io.PyramidIO;
 import com.oculusinfo.factory.ConfigurableFactory;
+import com.oculusinfo.factory.ConfigurationException;
 import com.oculusinfo.factory.properties.StringProperty;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.sql.SQLException;
 import java.util.List;
 
 
@@ -38,7 +40,7 @@ public class JDBCPyramidIOFactory extends ConfigurableFactory<PyramidIO> {
 	private static final Logger LOGGER = LoggerFactory.getLogger(JDBCPyramidIOFactory.class);
 
 
-	
+
 	public static StringProperty ROOT_PATH              = new StringProperty("root.path",
 		   "Indicates the root path of the tile pyramid - the URL of the database.  There is no default for this property.",
 		   null);
@@ -54,15 +56,13 @@ public class JDBCPyramidIOFactory extends ConfigurableFactory<PyramidIO> {
 	}
 
 	@Override
-	protected PyramidIO create() {
+	protected PyramidIO create() throws ConfigurationException {
 		try {
 			String driver = getPropertyValue(JDBC_DRIVER);
 			String rootPath = getPropertyValue(ROOT_PATH);
 			return new JDBCPyramidIO(driver, rootPath);
+		} catch (ClassNotFoundException | SQLException e) {
+			throw new ConfigurationException("Error creating JDBCPyramidIO", e);
 		}
-		catch (Exception e) {
-			LOGGER.error("Error trying to create JDBCPyramidIO", e);
-		}
-		return null;
 	}
 }

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/SQLitePyramidIO.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/SQLitePyramidIO.java
@@ -24,15 +24,17 @@
  */
 package com.oculusinfo.binning.io.impl;
 
+import java.sql.SQLException;
+
 /**
  * A SQLite-based JDBC PyramidIO.
- * 
+ *
  * @author rcameron
  *
  */
 public class SQLitePyramidIO extends JDBCPyramidIO {
 
-	public SQLitePyramidIO(String dbPath) throws Exception {
+	public SQLitePyramidIO(String dbPath) throws SQLException, ClassNotFoundException {
 		super("org.sqlite.JDBC", "jdbc:sqlite:" + dbPath);
 	}
 }

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/SQLitePyramidIOFactory.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/impl/SQLitePyramidIOFactory.java
@@ -26,11 +26,13 @@ package com.oculusinfo.binning.io.impl;
 
 import com.oculusinfo.binning.io.PyramidIO;
 import com.oculusinfo.factory.ConfigurableFactory;
+import com.oculusinfo.factory.ConfigurationException;
 import com.oculusinfo.factory.properties.StringProperty;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.sql.SQLException;
 import java.util.List;
 
 
@@ -50,14 +52,12 @@ public class SQLitePyramidIOFactory extends ConfigurableFactory<PyramidIO> {
 	}
 
 	@Override
-	protected PyramidIO create() {
+	protected PyramidIO create() throws ConfigurationException {
 		try {
 			String rootPath = getPropertyValue(ROOT_PATH);
 			return new SQLitePyramidIO(rootPath);
+		} catch (ClassNotFoundException | SQLException e) {
+			throw new ConfigurationException("Error creating SQLite pyramid IO", e);
 		}
-		catch (Exception e) {
-			LOGGER.error("Error trying to create SQLitePyramidIO", e);
-		}
-		return null;
 	}
 }

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/TileSerializerFactory.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/TileSerializerFactory.java
@@ -27,6 +27,7 @@ package com.oculusinfo.binning.io.serialization;
 import java.util.List;
 
 import com.oculusinfo.binning.io.serialization.impl.PrimitiveAvroSerializerFactory;
+import com.oculusinfo.factory.ConfigurationException;
 import org.apache.avro.file.CodecFactory;
 
 import com.oculusinfo.factory.ConfigurableFactory;
@@ -80,7 +81,7 @@ public class TileSerializerFactory
 		addProperty(DEFLATE_LEVEL);
 	}
 
-	public static <T> CodecFactory getCodecFactory (ConfigurableFactory<TileSerializer<T>> subFactory) {
+	public static <T> CodecFactory getCodecFactory (ConfigurableFactory<TileSerializer<T>> subFactory) throws ConfigurationException {
 		CodecType codecType = subFactory.getPropertyValue(CODEC_TYPE);
 		switch (codecType) {
 		case Snappy:

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/impl/KryoSerializerFactory.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/impl/KryoSerializerFactory.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.oculusinfo.factory.ConfigurationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -120,7 +121,7 @@ public class KryoSerializerFactory<T> extends ConfigurableFactory<TileSerializer
 	}
 
 	@Override
-	protected TileSerializer<T> create () {
+	protected TileSerializer<T> create () throws ConfigurationException {
 		// Check class registrations
 		List<String> classNames = getPropertyValue(NEEDED_CLASSES);
 		Codec codec = getPropertyValue(CODEC);

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/impl/PairArrayAvroSerializerFactory.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/impl/PairArrayAvroSerializerFactory.java
@@ -30,6 +30,7 @@ import java.util.List;
 
 import com.oculusinfo.binning.io.serialization.TileSerializer;
 import com.oculusinfo.binning.io.serialization.TileSerializerFactory;
+import com.oculusinfo.factory.ConfigurationException;
 import com.oculusinfo.factory.util.Pair;
 import com.oculusinfo.factory.ConfigurableFactory;
 
@@ -72,7 +73,7 @@ public class PairArrayAvroSerializerFactory<S, T>
 	}
 
 	@Override
-	protected TileSerializer<List<Pair<S, T>>> create () {
+	protected TileSerializer<List<Pair<S, T>>> create () throws ConfigurationException {
 		return new PairArrayAvroSerializer<S, T>(_keyType, _valueType, TileSerializerFactory.getCodecFactory(this));
 	}
 }

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/impl/PairAvroSerializerFactory.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/impl/PairAvroSerializerFactory.java
@@ -29,6 +29,7 @@ import java.util.List;
 import com.oculusinfo.binning.io.serialization.TileSerializer;
 import com.oculusinfo.binning.io.serialization.TileSerializerFactory;
 import com.oculusinfo.factory.ConfigurableFactory;
+import com.oculusinfo.factory.ConfigurationException;
 import com.oculusinfo.factory.util.Pair;
 
 /**
@@ -69,7 +70,7 @@ public class PairAvroSerializerFactory<S, T> extends ConfigurableFactory<TileSer
 	}
 
 	@Override
-	protected TileSerializer<Pair<S, T>> create () {
+	protected TileSerializer<Pair<S, T>> create () throws ConfigurationException {
 		return new PairAvroSerializer<S, T>(_keyType, _valueType, TileSerializerFactory.getCodecFactory(this));
 	}
 }

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/impl/PrimitiveArrayAvroSerializerFactory.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/impl/PrimitiveArrayAvroSerializerFactory.java
@@ -27,6 +27,7 @@ package com.oculusinfo.binning.io.serialization.impl;
 import com.oculusinfo.binning.io.serialization.TileSerializer;
 import com.oculusinfo.binning.io.serialization.TileSerializerFactory;
 import com.oculusinfo.factory.ConfigurableFactory;
+import com.oculusinfo.factory.ConfigurationException;
 
 import java.util.List;
 
@@ -60,7 +61,7 @@ public class PrimitiveArrayAvroSerializerFactory<T>  extends ConfigurableFactory
 	}
 
 	@Override
-	protected TileSerializer<List<T>> create () {
+	protected TileSerializer<List<T>> create () throws ConfigurationException {
 		return new PrimitiveArrayAvroSerializer<>(_entryType, TileSerializerFactory.getCodecFactory(this));
 	}
 }

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/impl/PrimitiveAvroSerializerFactory.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/io/serialization/impl/PrimitiveAvroSerializerFactory.java
@@ -27,6 +27,7 @@ package com.oculusinfo.binning.io.serialization.impl;
 import com.oculusinfo.binning.io.serialization.TileSerializer;
 import com.oculusinfo.binning.io.serialization.TileSerializerFactory;
 import com.oculusinfo.factory.ConfigurableFactory;
+import com.oculusinfo.factory.ConfigurationException;
 
 import java.util.List;
 
@@ -65,7 +66,7 @@ public class PrimitiveAvroSerializerFactory<T> extends ConfigurableFactory<TileS
 	}
 
 	@Override
-	protected TileSerializer<T> create () {
+	protected TileSerializer<T> create () throws ConfigurationException {
 		return new PrimitiveAvroSerializer<>(_type, TileSerializerFactory.getCodecFactory(this));
 	}
 }

--- a/binning-utilities/src/main/java/com/oculusinfo/binning/util/CopyPyramid.java
+++ b/binning-utilities/src/main/java/com/oculusinfo/binning/util/CopyPyramid.java
@@ -290,7 +290,7 @@ public class CopyPyramid<T> {
 		}
 
 		@Override
-		protected CopyParameters create() {
+		protected CopyParameters create() throws ConfigurationException {
 			return new CopyParameters(
 			                          getPropertyValue(SOURCE_ID),
 			                          getPropertyValue(DESTINATION_ID),

--- a/factory-utilities/src/main/java/com/oculusinfo/factory/SharedInstanceFactory.java
+++ b/factory-utilities/src/main/java/com/oculusinfo/factory/SharedInstanceFactory.java
@@ -38,11 +38,10 @@ import java.util.Map;
  * part related to the factory's properties, or those properties used to create
  * the product, so extraneous properties or configuration details will cause
  * false cache misses.
- * 
+ *
  * @author nkronenfeld
  */
-public abstract class SharedInstanceFactory<T> extends
-	                                               ConfigurableFactory<T> {
+public abstract class SharedInstanceFactory<T> extends ConfigurableFactory<T> {
 	/*
 	 * The static mapping containing all instances ever made. This maps from
 	 * factory type to configuration to object. Configurations are kepts as
@@ -70,7 +69,7 @@ public abstract class SharedInstanceFactory<T> extends
 	}
 
 	@Override
-	final protected T create () {
+	final protected T create () throws ConfigurationException {
 		synchronized (_instances) {
 			if (!_instances.containsKey(this.getClass())) {
 				_instances.put(this.getClass(), new HashMap<String, Object>());
@@ -84,5 +83,5 @@ public abstract class SharedInstanceFactory<T> extends
 		}
 	}
 
-	abstract protected T createInstance ();
+	abstract protected T createInstance () throws ConfigurationException;
 }

--- a/factory-utilities/src/main/java/com/oculusinfo/factory/UberFactory.java
+++ b/factory-utilities/src/main/java/com/oculusinfo/factory/UberFactory.java
@@ -88,7 +88,7 @@ public class UberFactory<T> extends ConfigurableFactory<T> {
 	}
 
 	@Override
-	protected T create () {
+	protected T create () throws ConfigurationException {
 		String subType = getPropertyValue(FACTORY_TYPE);
 		try {
 			return super.produce(subType, getFactoryType());

--- a/factory-utilities/src/test/java/com/oculusinfo/factory/ConfigurableFactoryTests.java
+++ b/factory-utilities/src/test/java/com/oculusinfo/factory/ConfigurableFactoryTests.java
@@ -65,7 +65,7 @@ public class ConfigurableFactoryTests {
 			addProperty(STRING_PROP);
 		}
 		@Override
-		protected FactoryResult create () {
+		protected FactoryResult create () throws ConfigurationException {
 			FactoryResult result = new FactoryResult();
 			result._int = getPropertyValue(INT_PROP);
 			result._double = getPropertyValue(DOUBLE_PROP);

--- a/factory-utilities/src/test/java/com/oculusinfo/factory/com/oculusinfo/factory/providers/StandardUberFactoryProviderTests.java
+++ b/factory-utilities/src/test/java/com/oculusinfo/factory/com/oculusinfo/factory/providers/StandardUberFactoryProviderTests.java
@@ -118,7 +118,7 @@ public class StandardUberFactoryProviderTests {
         }
 
         @Override
-        protected TestConstruct create() {
+        protected TestConstruct create() throws ConfigurationException {
             int value = getPropertyValue(VALUE);
             return new TestConstruct(getName(), getRootPath(), value);
         }

--- a/spark-tile-utilities/src/main/java/com/oculusinfo/sparktile/init/GraphTileSerializationFactory.java
+++ b/spark-tile-utilities/src/main/java/com/oculusinfo/sparktile/init/GraphTileSerializationFactory.java
@@ -28,6 +28,7 @@ import java.util.List;
 import com.oculusinfo.binning.io.serialization.TileSerializer;
 import com.oculusinfo.binning.io.serialization.TileSerializerFactory;
 import com.oculusinfo.factory.ConfigurableFactory;
+import com.oculusinfo.factory.ConfigurationException;
 import com.oculusinfo.factory.providers.AbstractFactoryProvider;
 import com.oculusinfo.tilegen.graph.analytics.GraphAnalyticsRecord;
 import com.oculusinfo.tilegen.graph.analytics.GraphAnalyticsAvroSerializer;
@@ -44,7 +45,7 @@ public class GraphTileSerializationFactory extends ConfigurableFactory<TileSeria
 	}
 
 	@Override
-	protected TileSerializer<List<GraphAnalyticsRecord>> create () {
+	protected TileSerializer<List<GraphAnalyticsRecord>> create () throws ConfigurationException {
 		return new GraphAnalyticsAvroSerializer(TileSerializerFactory.getCodecFactory(this));
 	}
 

--- a/tile-examples/twitter-topics/twitter-topics-utilities/src/main/java/com/oculusinfo/twitter/init/TwitterTileSerializationFactory.java
+++ b/tile-examples/twitter-topics/twitter-topics-utilities/src/main/java/com/oculusinfo/twitter/init/TwitterTileSerializationFactory.java
@@ -28,6 +28,7 @@ import java.util.List;
 import com.oculusinfo.binning.io.serialization.TileSerializer;
 import com.oculusinfo.binning.io.serialization.TileSerializerFactory;
 import com.oculusinfo.factory.ConfigurableFactory;
+import com.oculusinfo.factory.ConfigurationException;
 import com.oculusinfo.factory.providers.AbstractFactoryProvider;
 import com.oculusinfo.twitter.binning.TwitterDemoTopicRecord;
 import com.oculusinfo.twitter.binning.TwitterTopicAvroSerializer;
@@ -44,7 +45,7 @@ public class TwitterTileSerializationFactory extends ConfigurableFactory<TileSer
 	}
 
 	@Override
-	protected TileSerializer<List<TwitterDemoTopicRecord>> create () {
+	protected TileSerializer<List<TwitterDemoTopicRecord>> create () throws ConfigurationException {
 		return new TwitterTopicAvroSerializer(TileSerializerFactory.getCodecFactory(this));
 	}
 

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/ImageRendererFactory.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/ImageRendererFactory.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.oculusinfo.factory.ConfigurableFactory;
+import com.oculusinfo.factory.ConfigurationException;
 import com.oculusinfo.factory.properties.StringProperty;
 import com.oculusinfo.tile.rendering.color.ColorRampFactory;
 import com.oculusinfo.tile.rendering.impl.NumberListHeatMapImageRenderer;
@@ -67,7 +68,7 @@ public class ImageRendererFactory extends ConfigurableFactory<TileDataImageRende
 
 
 	@Override
-	protected TileDataImageRenderer<?> create () {
+	protected TileDataImageRenderer<?> create () throws ConfigurationException {
 		String rendererType = getPropertyValue(RENDERER_TYPE);
 
 		rendererType = rendererType.toLowerCase();

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/LayerConfiguration.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/LayerConfiguration.java
@@ -191,7 +191,7 @@ public class LayerConfiguration extends ConfigurableFactory<LayerConfiguration> 
 	}
 
 	@Override
-	public <PT> PT getPropertyValue (ConfigurationProperty<PT> property) {
+	public <PT> PT getPropertyValue (ConfigurationProperty<PT> property) throws ConfigurationException {
 		if (LOCAL_PROPERTIES.contains(property)) {
             if (TILE_COORDINATE.equals(property)) {
 				return property.getType().cast(_tileCoordinate);
@@ -222,8 +222,14 @@ public class LayerConfiguration extends ConfigurableFactory<LayerConfiguration> 
 				Pair<Double, Double> extrema = tileTransformer.getTransformedExtrema(this);
 				_transformFactory.setExtrema(extrema.getFirst(), extrema.getSecond());
 			}
-		} catch (ConfigurationException e) {
-			LOGGER.warn("Error determining layer-specific extrema for "+getPropertyValue(LAYER_ID));
+		} catch (ConfigurationException e1) {
+			String layer;
+			try {
+				layer = getPropertyValue(LAYER_ID);
+			} catch (ConfigurationException e2) {
+				layer = "unknown layer";
+			}
+			LOGGER.warn("Error determining layer-specific extrema for "+layer);
 		}
 	}
 

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/color/ColorRampFactory.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/color/ColorRampFactory.java
@@ -104,7 +104,7 @@ public class ColorRampFactory extends ConfigurableFactory<ColorRamp> {
 	}
 
 	@Override
-	protected ColorRamp create () {
+	protected ColorRamp create () throws ConfigurationException {
 		final String rampType = getPropertyValue(RAMP_TYPE);
 		final double opacity = 1.0; //getPropertyValue(OPACITY);
 		final String theme = getPropertyValue(THEME);
@@ -159,11 +159,11 @@ public class ColorRampFactory extends ConfigurableFactory<ColorRamp> {
 		// FLAT
 		} else if (rampType.equalsIgnoreCase("flat")) {
 			Color color = hasPropertyValue(COLOR1)?
-					ColorRampParameter.getColor(getPropertyValue(COLOR1)) : 
+					ColorRampParameter.getColor(getPropertyValue(COLOR1)) :
 						islight? new Color(55,55,55) : Color.WHITE;
-						
+
 			ramp = new FlatColorRamp(color, opacity);
-			
+
 		// LEGACY GRADIENT
 		} else if (rampType.equalsIgnoreCase("single-gradient")) {
 			int alpha1 = getPropertyValue(ALPHA1);

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/color/ThemedGradientFactory.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/color/ThemedGradientFactory.java
@@ -96,16 +96,16 @@ public class ThemedGradientFactory extends ConfigurableFactory<ThemedGradient> {
 	 * Returns the theme name.
 	 * @return the theme name
 	 */
-	public String getTheme() {
+	public String getTheme() throws ConfigurationException {
 		return getPropertyValue(THEME);
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see com.oculusinfo.factory.ConfigurableFactory#create()
 	 */
 	@Override
-	protected ThemedGradient create() {
-		
+	protected ThemedGradient create() throws ConfigurationException {
+
 		final String theme = getTheme();
 		final List<Color> colors = new ArrayList<Color>();
 		final JSONArray jcolors = getPropertyValue(COLORS);

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/impl/NumberStatisticImageRenderer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/impl/NumberStatisticImageRenderer.java
@@ -80,10 +80,11 @@ public class NumberStatisticImageRenderer implements TileDataImageRenderer<Numbe
 	@Override
 	public BufferedImage render(TileData<Number> data, LayerConfiguration config) {
 		BufferedImage bi;
-		String layerId = config.getPropertyValue(LayerConfiguration.LAYER_ID);
-		TileIndex index = config.getPropertyValue(LayerConfiguration.TILE_COORDINATE);
+		String layerId = null;
+		TileIndex index = null;
 
 		try {
+			layerId = config.getPropertyValue(LayerConfiguration.LAYER_ID);
 			index = config.getPropertyValue(LayerConfiguration.TILE_COORDINATE);
 			int width = config.getPropertyValue(LayerConfiguration.OUTPUT_WIDTH);
 			int height = config.getPropertyValue(LayerConfiguration.OUTPUT_HEIGHT);

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/impl/TopTextScoresImageRenderer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/impl/TopTextScoresImageRenderer.java
@@ -114,10 +114,11 @@ public class TopTextScoresImageRenderer implements TileDataImageRenderer<List<Pa
 	@Override
 	public BufferedImage render(TileData<List<Pair<String, Double>>> data, LayerConfiguration config) {
 		BufferedImage bi;
-		String layerId = config.getPropertyValue(LayerConfiguration.LAYER_ID);
-
-		TileIndex index = config.getPropertyValue(LayerConfiguration.TILE_COORDINATE);
+		String layerId = null;
+		TileIndex index = null;
 		try {
+			layerId = config.getPropertyValue(LayerConfiguration.LAYER_ID);
+			index = config.getPropertyValue(LayerConfiguration.TILE_COORDINATE);
 			int width = config.getPropertyValue(LayerConfiguration.OUTPUT_WIDTH);
 			int height = config.getPropertyValue(LayerConfiguration.OUTPUT_HEIGHT);
 

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/BucketTileTransformer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/BucketTileTransformer.java
@@ -99,7 +99,12 @@ public abstract class BucketTileTransformer<T> implements TileTransformer<List<T
 	 */
 	private List<Double> parseExtremum (LayerConfiguration parameter, StringProperty property, String propName,
 	                                          String layer, Double def) {
-		String rawValue = parameter.getPropertyValue(property);
+		String rawValue;
+		try {
+			rawValue = parameter.getPropertyValue(property);
+		} catch (ConfigurationException e) {
+			rawValue = null;
+		}
 		ArrayList<Double> values = null;
 
 		// If the is no extremum info available return the default.

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/FilterVarsDoubleArrayTileTransformer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/FilterVarsDoubleArrayTileTransformer.java
@@ -38,6 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static com.oculusinfo.tile.rendering.LayerConfiguration.*;
@@ -184,26 +185,25 @@ public class FilterVarsDoubleArrayTileTransformer<T> implements TileTransformer<
 	// Extracts all the extrema
 	private List<Double> parseExtremum (LayerConfiguration parameter, StringProperty property, String propName,
 										String layer, Double def) {
-		String rawValue = parameter.getPropertyValue(property);
-		ArrayList<Double> values = null;
+		String rawValue = null;
 		// Convert string into json object
 		try {
+			rawValue = parameter.getPropertyValue(property);
 			JSONArray ex = new JSONArray(rawValue);
-			values = new ArrayList<>(ex.length());
+			List<Double> values = new ArrayList<>(ex.length());
 			for (int i = 0; i < ex.length(); i++) {
 				values.add(ex.getJSONObject(i).getDouble(propName));
 			}
 			return values;
+		} catch (ConfigurationException e) {
+			LOGGER.warn("Can not determine value for property "+propName+", defaulting to " + def);
+			return Arrays.asList(def);
 		} catch (NumberFormatException|NullPointerException e) {
 			LOGGER.warn("Bad " + propName + " value " + rawValue + " for " + layer + ", defaulting to " + def);
-			values.clear();
-			values.add(def);
-			return values;
+			return Arrays.asList(def);
 		} catch (JSONException e) {
-			LOGGER.warn("JSON parse exception", e);
-			values.clear();
-			values.add(def);
-			return values;
+			LOGGER.warn("JSON parse exception for property "+propName+", defaulting to "+def, e);
+			return Arrays.asList(def);
 		}
 	}
 }

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/IdentityTileTransformer.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/IdentityTileTransformer.java
@@ -78,11 +78,16 @@ public class IdentityTileTransformer<T> implements TileTransformer<T> {
 	}
 
 	private double parseExtremum (LayerConfiguration parameter, StringProperty property, String propName, String layer, double def) {
-		String rawValue = parameter.getPropertyValue(property);
 		try {
-			return Double.parseDouble(rawValue);
-		} catch (NumberFormatException|NullPointerException e) {
-			LOGGER.warn("Bad "+propName+" value "+rawValue+" for "+layer+", defaulting to "+def);
+			String rawValue = parameter.getPropertyValue(property);
+			try {
+				return Double.parseDouble(rawValue);
+			} catch (NumberFormatException | NullPointerException e) {
+				LOGGER.warn("Bad " + propName + " value " + rawValue + " for " + layer + ", defaulting to " + def);
+				return def;
+			}
+		} catch (ConfigurationException e) {
+			LOGGER.warn("Could not determine value for property " + propName + " for " + layer + ", defaulting to " + def);
 			return def;
 		}
 	}

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/TileTransformerFactory.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/tile/TileTransformerFactory.java
@@ -25,6 +25,7 @@ package com.oculusinfo.tile.rendering.transformations.tile;
 
 import java.util.List;
 
+import com.oculusinfo.factory.ConfigurationException;
 import org.json.JSONObject;
 
 import com.oculusinfo.factory.ConfigurableFactory;
@@ -73,7 +74,7 @@ public class TileTransformerFactory extends ConfigurableFactory<TileTransformer<
 	}
 
 	@Override
-	protected TileTransformer<?> create () {
+	protected TileTransformer<?> create () throws ConfigurationException {
 
 		String transformerTypes = getPropertyValue(TILE_TRANSFORMER_TYPE);
 

--- a/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/value/ValueTransformerFactory.java
+++ b/tile-rendering/src/main/java/com/oculusinfo/tile/rendering/transformations/value/ValueTransformerFactory.java
@@ -25,6 +25,7 @@
 package com.oculusinfo.tile.rendering.transformations.value;
 
 import com.oculusinfo.factory.ConfigurableFactory;
+import com.oculusinfo.factory.ConfigurationException;
 import com.oculusinfo.factory.ConfigurationProperty;
 import com.oculusinfo.factory.properties.DoubleProperty;
 import com.oculusinfo.factory.properties.StringProperty;
@@ -98,7 +99,7 @@ public class ValueTransformerFactory extends ConfigurableFactory<ValueTransforme
 	}
 
 	@Override
-	public <PT> PT getPropertyValue (ConfigurationProperty<PT> property) {
+	public <PT> PT getPropertyValue (ConfigurationProperty<PT> property) throws ConfigurationException {
 		if (LAYER_MAXIMUM.equals(property)) {
 			return property.getType().cast(_layerMaximum);
 		} else if (LAYER_MINIMUM.equals(property)) {
@@ -108,7 +109,7 @@ public class ValueTransformerFactory extends ConfigurableFactory<ValueTransforme
 	}
 
 	@Override
-	protected ValueTransformer<?> create () {
+	protected ValueTransformer<?> create () throws ConfigurationException {
 		String name = getPropertyValue(TRANSFORM_NAME);
 		double layerMin = getPropertyValue(LAYER_MINIMUM);
 		double layerMax = getPropertyValue(LAYER_MAXIMUM);

--- a/tile-service/src/main/java/com/oculusinfo/tile/init/providers/CachingLayerConfigurationProvider.java
+++ b/tile-service/src/main/java/com/oculusinfo/tile/init/providers/CachingLayerConfigurationProvider.java
@@ -161,9 +161,13 @@ public class CachingLayerConfigurationProvider extends AbstractFactoryProvider<L
 
 		private void setupBasePyramidIO () {
 			if (!_baseInitialized) {
-				String pyramidId = _parent.getPropertyValue(LayerConfiguration.LAYER_ID);
-				_pyramidIO.setupBasePyramidIO(pyramidId, _baseFactory);
-				_baseInitialized = true;
+				try {
+					String pyramidId = _parent.getPropertyValue(LayerConfiguration.LAYER_ID);
+					_pyramidIO.setupBasePyramidIO(pyramidId, _baseFactory);
+					_baseInitialized = true;
+				} catch (ConfigurationException e) {
+					LOGGER.warn("Error determining layer id", e);
+				}
 			}
 		}
 

--- a/tile-service/src/main/java/com/oculusinfo/tile/rest/layer/LayerResource.java
+++ b/tile-service/src/main/java/com/oculusinfo/tile/rest/layer/LayerResource.java
@@ -99,6 +99,8 @@ public class LayerResource extends ServerResource {
 			return layer;
 		} catch ( JSONException e ) {
 			throw new JSONException( "Bad layer request, layer " + layerId + " does not exist" );
+		} catch ( ConfigurationException e ) {
+			throw new JSONException( "Bad layer request, layer " + layerId + " has no rest endpoint." );
 		}
 	}
 

--- a/tile-service/src/main/java/com/oculusinfo/tile/rest/tile/TileServiceImpl.java
+++ b/tile-service/src/main/java/com/oculusinfo/tile/rest/tile/TileServiceImpl.java
@@ -141,8 +141,14 @@ public class TileServiceImpl implements TileService {
 
 		// always return a blank tile if there is no data
 		if ( bi == null ) {
-			int outputWidth = config.getPropertyValue( LayerConfiguration.OUTPUT_WIDTH );
-			int outputHeight = config.getPropertyValue( LayerConfiguration.OUTPUT_HEIGHT );
+			int outputWidth = 256;
+			int outputHeight = 256;
+			try {
+				outputWidth = config.getPropertyValue(LayerConfiguration.OUTPUT_WIDTH);
+				outputHeight = config.getPropertyValue(LayerConfiguration.OUTPUT_HEIGHT);
+			} catch (ConfigurationException e) {
+				LOGGER.warn("Error reading image height or width; defaulting to "+outputWidth+" x "+outputHeight, e);
+			}
 			bi = new BufferedImage( outputWidth, outputHeight, BufferedImage.TYPE_INT_ARGB );
 			Graphics2D g = bi.createGraphics();
 			g.setColor( COLOR_BLANK );

--- a/tile-service/src/test/java/com/oculusinfo/tile/rest/layer/LayerServiceTests.java
+++ b/tile-service/src/test/java/com/oculusinfo/tile/rest/layer/LayerServiceTests.java
@@ -27,6 +27,7 @@ import com.oculusinfo.binning.io.DefaultPyramidIOFactoryProvider;
 import com.oculusinfo.binning.io.PyramidIO;
 import com.oculusinfo.binning.io.serialization.DefaultTileSerializerFactoryProvider;
 import com.oculusinfo.binning.io.serialization.TileSerializer;
+import com.oculusinfo.factory.ConfigurationException;
 import com.oculusinfo.factory.providers.FactoryProvider;
 import com.oculusinfo.tile.init.providers.StandardImageRendererFactoryProvider;
 import com.oculusinfo.tile.init.providers.StandardLayerConfigurationProvider;
@@ -120,7 +121,7 @@ public class LayerServiceTests {
 	}
 
 	@Test
-	public void getLayerConfigurationTest() {
+	public void getLayerConfigurationTest() throws ConfigurationException {
 		LayerConfiguration layerConfig0 = _layerService.getLayerConfiguration( "test-layer0", null );
 		LayerConfiguration layerConfig1 = _layerService.getLayerConfiguration( "test-layer1", null );
 		System.out.println( layerConfig0.getPropertyValue( LayerConfiguration.LAYER_ID ) );


### PR DESCRIPTION
a. Don't swallow so many errors - throw early, throw often.
b. Note when default values are used at the warning level - this is what happens when a property name is misspelled, and is the best I can see to do for that case.