### PR TITLE
CDH Versioning and Backtick Quotes Bugfix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,18 @@ task setBuildVersions {
 	// Aperture tiles requires, at a minimum, Spark 1.3.0 and HBase 1.0
 	switch (buildType) {
 	// No cloudera version before 5.4.0 meets our minimum requirements
+		case "cdh5.4.7":
+			logger.info "Valid build type found - using $buildType"
+			project.ext { // apply project scope to vars, otherwise local to task
+				hadoopCommonVersion = "2.6.0-cdh5.4.7"
+				hadoopCoreVersion = "2.6.0-mr1-cdh5.4.7"
+				hbaseVersion = "1.0.0-cdh5.4.7"
+				htraceVersion = "3.1.0-incubating"
+				sparkVersion = "1.3.0-cdh5.4.7"
+				dependencyScalaVersion = "2.10"
+				scalaVersion = "2.10.3"
+			}
+			break
 		case "cdh5.4.1":
 			logger.info "Valid build type found - using $buildType"
 			project.ext { // apply project scope to vars, otherwise local to task

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-# build for cloudera 5.4.1 by default - see build.gradle for additional supported variants
-buildType=cdh5.4.1
+# build for cloudera 5.4.7 by default - see build.gradle for additional supported variants
+buildType=cdh5.4.7
 
 # build all projects - see build.gradle for addtional support sub-configs
 buildProjects=all

--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/pipeline/PipelineOperations.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/pipeline/PipelineOperations.scala
@@ -95,9 +95,9 @@ object PipelineOperations {
 		PipelineData(rdd.sqlContext, rdd, tableName)
 	}
 
-	private def coalesce (sqlc: SQLContext, dataFrame: DataFrame, partitions: Option[Int]): DataFrame = {
+	def coalesce (sqlc: SQLContext, dataFrame: DataFrame, partitions: Option[Int]): DataFrame = {
 		partitions.map{n =>
-			val baseRDD = dataFrame.queryExecution.toRdd
+			val baseRDD = dataFrame.rdd
 			val curPartitions = baseRDD.partitions.size
 			// if we're increasing the number of partitions, just repartition as per normal
 			// If we're reducing them, copy data and coalesce, so as to avoid a shuffle.

--- a/tile-generation/src/main/scala/com/oculusinfo/tilegen/util/HdfsFileManager.scala
+++ b/tile-generation/src/main/scala/com/oculusinfo/tilegen/util/HdfsFileManager.scala
@@ -1,3 +1,29 @@
+/*
+ * Copyright © 2013-2015 Uncharted Software Inc.
+ *
+ * Property of Uncharted™, formerly Oculus Info Inc.
+ * http://uncharted.software/
+ *
+ * Released under the MIT License.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.oculusinfo.tilegen.util
 
 import java.io.{OutputStreamWriter, BufferedWriter}


### PR DESCRIPTION
Added copyright header, made some changes to build with newer version of CDH, enable coalesce() to run with Spark 1.5, fix bug with backtick quotes.